### PR TITLE
Use eventDate instead of lastUpdated

### DIFF
--- a/app/src/main/java/org/hisp/dhis/android/sdk/controllers/tracker/TrackerDataLoader.java
+++ b/app/src/main/java/org/hisp/dhis/android/sdk/controllers/tracker/TrackerDataLoader.java
@@ -253,13 +253,13 @@ final class TrackerDataLoader extends ResourceController {
 
     private static String findLastEvent(DhisApi dhisApi, String organisationUnitUid, String programUid){
         final Map<String, String> map = new HashMap<>();
-        map.put("fields", "event,lastUpdated");
+        map.put("fields", "event,eventDate");
 
         Event lastEvent=null;
         JsonNode response = dhisApi.getMinimizedEvents(programUid, organisationUnitUid, map);
         List<Event> pageEvents = EventsWrapper.getEvents(response);
         for(Event event:pageEvents){
-            if(lastEvent==null || DateUtils.parseDate(lastEvent.getLastUpdated()).before(DateUtils.parseDate(event.getLastUpdated()))){
+            if(lastEvent==null || DateUtils.parseDate(lastEvent.getEventDate()).before(DateUtils.parseDate(event.getEventDate()))){
                 lastEvent = event;
             }
         }


### PR DESCRIPTION
Closes https://github.com/EyeSeeTea/malariapp/issues/1365
Solves: 
Last survey date bug. On Mali -> Mopti -> BANKASS -> CSRef BANKASS last survey on 2017 is not shown in the app

