### PR TITLE
clear radio group viewholder view to display the correct button check

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/adapters/rows/dataentry/RadioButtonsRow.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/adapters/rows/dataentry/RadioButtonsRow.java
@@ -73,6 +73,11 @@ public class RadioButtonsRow extends Row {
         if (convertView != null && convertView.getTag() instanceof BooleanRowHolder) {
             view = convertView;
             holder = (BooleanRowHolder) convertView.getTag();
+            RadioGroup.OnCheckedChangeListener listener = holder.radioGroupCheckedChangeListener;
+            holder.radioGroup.setOnCheckedChangeListener(null);
+            holder.radioGroup.clearCheck();
+            holder.radioGroup.setOnCheckedChangeListener(listener);
+            holder.updateViews(mLabel, mValue);
         } else {
             View root = inflater.inflate(
                     R.layout.listview_row_radio_buttons, container, false);


### PR DESCRIPTION
Closes EyeSeeTea/dhis2-android-trackercapture#9

I created this PR to merge a more clean branch.
It comes from this PR: https://github.com/EyeSeeTea/dhis2-android-sdk/pull/130