### PR TITLE
Put error label visibility to gone to not occupy space if there is no…

### DIFF
--- a/core/src/main/res/layout/listview_row_text_view_label.xml
+++ b/core/src/main/res/layout/listview_row_text_view_label.xml
@@ -83,6 +83,7 @@
 
     <org.hisp.dhis.android.sdk.ui.views.FontTextView
         android:id="@+id/error_label"
+        android:visibility="gone"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="4dp"


### PR DESCRIPTION
Close #https://github.com/EyeSeeTea/dhis2-android-trackercapture/issues/99