### PR TITLE
Bug legacy event logout crash

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/controllers/DhisController.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/controllers/DhisController.java
@@ -62,11 +62,16 @@ public final class DhisController {
     private final static String CREDENTIALS = "credentials";
 
     /**
-     * Variable hasUnSynchronizedDatavalues
-     * Is set to true when submitting changes in DataEntryFragment, TrackedEntityInstanceProfileFragment (in Tracker Capture) and when no network is available
-     * Is set to false when DataValueSender.onFinishSending(true)
+     * Variable hasSynchronizedActiveProcess
+     * Is set to true when a sync process is active
      */
-    public static boolean hasUnSynchronizedDatavalues;
+    public static boolean hasSynchronizedActiveProcess;
+    /**
+     * Variable hasLogoutDialogActive
+     * Is set to true when a the logout dialog is active
+     * Is used to prevent new syncs process.
+     */
+    public static boolean hasLogoutDialogActive;
 
     private ObjectMapper objectMapper;
     private DhisApi dhisApi;

--- a/core/src/main/java/org/hisp/dhis/android/sdk/controllers/DhisController.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/controllers/DhisController.java
@@ -62,10 +62,10 @@ public final class DhisController {
     private final static String CREDENTIALS = "credentials";
 
     /**
-     * Variable hasSynchronizedActiveProcess
+     * Variable hasSynchronizationActiveProcess
      * Is set to true when a sync process is active
      */
-    public static boolean hasSynchronizedActiveProcess;
+    public static boolean hasSynchronizationActiveProcess;
     /**
      * Variable hasLogoutDialogActive
      * Is set to true when a the logout dialog is active

--- a/core/src/main/java/org/hisp/dhis/android/sdk/services/PeriodicSynchronizer.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/services/PeriodicSynchronizer.java
@@ -70,6 +70,10 @@ public class PeriodicSynchronizer extends BroadcastReceiver {
             cancelPeriodicSynchronizer(context);
             return;
         }
+        if(DhisController.hasLogoutDialogActive){
+            Log.d(this.getClass().getName(), "haslogoutdialogactive: "+DhisController.hasLogoutDialogActive);
+            return;
+        }
         DhisService.synchronize(context, SyncStrategy.DOWNLOAD_ONLY_NEW);
 	}
 

--- a/core/src/main/java/org/hisp/dhis/android/sdk/services/PeriodicSynchronizer.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/services/PeriodicSynchronizer.java
@@ -71,6 +71,7 @@ public class PeriodicSynchronizer extends BroadcastReceiver {
             return;
         }
         if(DhisController.hasLogoutDialogActive){
+            //When the logout dialog is active the sync can't be launch to prevent logout crashes.
             Log.d(this.getClass().getName(), "haslogoutdialogactive: "+DhisController.hasLogoutDialogActive);
             return;
         }

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/dialogs/CustomDialogFragment.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/dialogs/CustomDialogFragment.java
@@ -47,8 +47,10 @@ public class CustomDialogFragment
     OnClickListener firstOptionListener;
     OnClickListener secondOptionListener;
     OnClickListener thirdOptionListener;
+    Callback mCallback;
+
     int iconId = -1;
-    
+
     public CustomDialogFragment(String title, String message, String firstOption, OnClickListener firstOptionListener) {
     	this.title = title;
         this.message = message;
@@ -66,7 +68,7 @@ public class CustomDialogFragment
         this.firstOptionListener = firstOptionListener;
         this.secondOption = null;
     }
-    
+
     public CustomDialogFragment(String title, String message, String firstOption)
     {
         this.title = title;
@@ -75,7 +77,7 @@ public class CustomDialogFragment
         this.secondOption = null;
         this.firstOptionListener = null;
     }
-    
+
     public CustomDialogFragment(String title, String message, String firstOption, String secondOption, OnClickListener firstOptionListener)
     {
         this.title = title;
@@ -94,7 +96,7 @@ public class CustomDialogFragment
         this.iconId = iconId;
         this.firstOptionListener = firstOptionListener;
     }
-    
+
     public CustomDialogFragment(String title, String message, String firstOption, String secondOption, OnClickListener firstOptionListener,
     		OnClickListener secondOptionListener)
     {
@@ -123,7 +125,8 @@ public class CustomDialogFragment
                                 String secondOption, String thirdOption,
                                 OnClickListener firstOptionListener,
                                 OnClickListener secondOptionListener,
-                                OnClickListener thirdOptionListener) {
+                                OnClickListener thirdOptionListener,
+            Callback mCallback) {
         this.title = title;
         this.message = message;
         this.firstOption = firstOption;
@@ -132,6 +135,7 @@ public class CustomDialogFragment
         this.firstOptionListener = firstOptionListener;
         this.secondOptionListener = secondOptionListener;
         this.thirdOptionListener = thirdOptionListener;
+        this.mCallback = mCallback;
     }
 
     @Override
@@ -154,15 +158,26 @@ public class CustomDialogFragment
                 {
                     dialog.dismiss();
                 }
-            }; 
+            };
         if(secondOption !=null) {
             alertDialogBuilder.setNegativeButton(secondOption, secondOptionListener);
         }
         if(thirdOption!=null) {
             alertDialogBuilder.setNeutralButton(thirdOption, thirdOptionListener);
         }
-
-
         return alertDialogBuilder.create();
+    }
+
+
+    @Override
+    public void onCancel(DialogInterface dialog) {
+        super.onCancel(dialog);
+        if(mCallback!=null){
+            mCallback.cancel();
+        }
+    }
+
+    public interface Callback {
+        public void cancel();
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/settings/SettingsFragment.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/settings/SettingsFragment.java
@@ -117,28 +117,39 @@ public class SettingsFragment extends Fragment
     @Override
     public void onClick(View view) {
         if (view.getId() == R.id.settings_logout_button) {
-            UiUtils.showConfirmDialog(getActivity(), getString(R.string.logout_title), getString(R.string.logout_message),
-                    getString(R.string.logout_option), getString(R.string.cancel_option), new DialogInterface.OnClickListener() {
+            DhisController.hasLogoutDialogActive = true;
+            UiUtils.showConfirmDialog(getActivity(), getString(R.string.logout_title),
+                    getString(R.string.logout_message),
+                    getString(R.string.logout_option), getString(R.string.cancel_option),
+                    new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
-
-                            if (DhisController.hasUnSynchronizedDatavalues) {
+                            DhisController.hasLogoutDialogActive = false;
+                            if (DhisController.hasSynchronizedActiveProcess) {
                                 //show error dialog
-                                UiUtils.showErrorDialog(getActivity(), getString(R.string.error_message),
-                                        getString(R.string.unsynchronized_data_values),
+                                UiUtils.showErrorDialog(getActivity(),
+                                        getString(R.string.error_message),
+                                        getString(R.string.synchronizing_data),
                                         new DialogInterface.OnClickListener() {
-
                                             @Override
                                             public void onClick(DialogInterface dialog, int which) {
                                                 dialog.dismiss();
                                             }
                                         });
                             } else {
+
                                 DhisService.logOutUser(getActivity());
-                                Intent intent = new Intent(getActivity().getApplicationContext(), LoginActivity.class);
+                                Intent intent = new Intent(getActivity().getApplicationContext(),
+                                        LoginActivity.class);
                                 startActivity(intent);
                                 getActivity().finish();
                             }
+                        }
+                    }, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            DhisController.hasLogoutDialogActive = false;
+                            dialog.dismiss();
                         }
                     });
         } else if (view.getId() == R.id.settings_sync_button) {
@@ -236,6 +247,7 @@ public class SettingsFragment extends Fragment
     }
 
     private void startSync() {
+        DhisController.hasSynchronizedActiveProcess = true;
         changeUiVisibility(false);
         setText(getProgressMessage());
     }
@@ -245,6 +257,7 @@ public class SettingsFragment extends Fragment
         syncTextView.setText("");
         synchronizeButton.setText(R.string.synchronize_with_server);
         synchronizeRemovedEventsButton.setText(R.string.synchronize_deleted_events);
+        DhisController.hasSynchronizedActiveProcess = false;
     }
 
     private void changeUiVisibility(boolean enabled) {

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/settings/SettingsFragment.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/settings/SettingsFragment.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.android.sdk.events.LoadingMessageEvent;
 import org.hisp.dhis.android.sdk.events.UiEvent;
 import org.hisp.dhis.android.sdk.persistence.Dhis2Application;
 import org.hisp.dhis.android.sdk.ui.activities.LoginActivity;
+import org.hisp.dhis.android.sdk.ui.dialogs.CustomDialogFragment;
 import org.hisp.dhis.android.sdk.utils.UiUtils;
 
 /**
@@ -120,20 +121,33 @@ public class SettingsFragment extends Fragment
             DhisController.hasLogoutDialogActive = true;
             UiUtils.showConfirmDialog(getActivity(), getString(R.string.logout_title),
                     getString(R.string.logout_message),
-                    getString(R.string.logout_option), getString(R.string.cancel_option),
+                    getString(R.string.logout_option),
+                    null,
+                    getString(R.string.cancel_option),
                     new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
-                            DhisController.hasLogoutDialogActive = false;
                             if (DhisController.hasSynchronizationActiveProcess) {
                                 //show error dialog
                                 UiUtils.showErrorDialog(getActivity(),
                                         getString(R.string.error_message),
                                         getString(R.string.synchronizing_data),
+                                        getString(R.string.ok_option),
+                                        null,
+                                        null,
                                         new DialogInterface.OnClickListener() {
                                             @Override
                                             public void onClick(DialogInterface dialog, int which) {
                                                 dialog.dismiss();
+                                                DhisController.hasLogoutDialogActive = false;
+                                            }
+                                        },
+                                        null,
+                                        null,
+                                        new CustomDialogFragment.Callback() {
+                                            @Override
+                                            public void cancel() {
+                                                DhisController.hasLogoutDialogActive = false;
                                             }
                                         });
                             } else {
@@ -143,6 +157,7 @@ public class SettingsFragment extends Fragment
                                         LoginActivity.class);
                                 startActivity(intent);
                                 getActivity().finish();
+                                DhisController.hasLogoutDialogActive = false;
                             }
                         }
                     }, new DialogInterface.OnClickListener() {
@@ -150,6 +165,13 @@ public class SettingsFragment extends Fragment
                         public void onClick(DialogInterface dialog, int which) {
                             DhisController.hasLogoutDialogActive = false;
                             dialog.dismiss();
+                        }
+                    },
+                    null,
+                    new CustomDialogFragment.Callback() {
+                        @Override
+                        public void cancel() {
+                            DhisController.hasLogoutDialogActive = false;
                         }
                     });
         } else if (view.getId() == R.id.settings_sync_button) {

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/settings/SettingsFragment.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/settings/SettingsFragment.java
@@ -125,7 +125,7 @@ public class SettingsFragment extends Fragment
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             DhisController.hasLogoutDialogActive = false;
-                            if (DhisController.hasSynchronizedActiveProcess) {
+                            if (DhisController.hasSynchronizationActiveProcess) {
                                 //show error dialog
                                 UiUtils.showErrorDialog(getActivity(),
                                         getString(R.string.error_message),
@@ -247,7 +247,7 @@ public class SettingsFragment extends Fragment
     }
 
     private void startSync() {
-        DhisController.hasSynchronizedActiveProcess = true;
+        DhisController.hasSynchronizationActiveProcess = true;
         changeUiVisibility(false);
         setText(getProgressMessage());
     }
@@ -257,7 +257,7 @@ public class SettingsFragment extends Fragment
         syncTextView.setText("");
         synchronizeButton.setText(R.string.synchronize_with_server);
         synchronizeRemovedEventsButton.setText(R.string.synchronize_deleted_events);
-        DhisController.hasSynchronizedActiveProcess = false;
+        DhisController.hasSynchronizationActiveProcess = false;
     }
 
     private void changeUiVisibility(boolean enabled) {

--- a/core/src/main/java/org/hisp/dhis/android/sdk/utils/UiUtils.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/utils/UiUtils.java
@@ -101,6 +101,22 @@ public final class UiUtils {
         });
     }
 
+    public static void showErrorDialog(final Activity activity, final String title, final String message,
+            final String confirmOption, final String cancelOption, final String neutralOption,
+            final DialogInterface.OnClickListener onConfirmListener,
+            final DialogInterface.OnClickListener onNegativeListener,
+            final DialogInterface.OnClickListener onNeutralListener,
+            final CustomDialogFragment.Callback callback) {
+        if (activity == null) return;
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                new CustomDialogFragment(title, message, confirmOption, cancelOption, neutralOption, onConfirmListener, onNegativeListener,
+                        onNeutralListener, callback).show(activity.getFragmentManager(), title);
+            }
+        });
+    }
+
     public static void showConfirmDialog(final Activity activity, final String title, final String message,
                                          final String confirmOption, final String cancelOption,
                                          DialogInterface.OnClickListener onClickListener) {
@@ -131,12 +147,23 @@ public final class UiUtils {
     }
 
     public static void showConfirmDialog(final Activity activity, final String title, final String message,
+            final String confirmOption, final String cancelOption, final String neutralOption,
+            DialogInterface.OnClickListener onConfirmListener,
+            DialogInterface.OnClickListener onNegativeListener,
+            DialogInterface.OnClickListener onNeutralListener,
+            CustomDialogFragment.Callback callback) {
+        new CustomDialogFragment(title, message, confirmOption, cancelOption, neutralOption, onConfirmListener, onNegativeListener,
+                onNeutralListener, callback).
+                show(activity.getFragmentManager(), title);
+    }
+
+    public static void showConfirmDialog(final Activity activity, final String title, final String message,
                                          final String firstOption, final String secondOption, final String thirdOption,
                                          DialogInterface.OnClickListener firstOptionListener,
                                          DialogInterface.OnClickListener secondOptionListener,
                                          DialogInterface.OnClickListener thirdOptionListener) {
         new CustomDialogFragment(title, message, firstOption, secondOption, thirdOption,
-                firstOptionListener, secondOptionListener, thirdOptionListener).
+                firstOptionListener, secondOptionListener, thirdOptionListener, null).
                 show(activity.getFragmentManager(), title);
     }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -226,7 +226,7 @@
     <string name="select_all">Select all</string>
     <string name="deselect_all">Deselect all</string>
     <string name="query_tracked_entity_instances">Online Query Tracked Entity Instances</string>
-    <string name="unsynchronized_data_values">You need to synchronize your changes with the server before logging out. Please check your Internet connection and press the synchronization button</string>
+    <string name="synchronizing_data">You must wait for the synchronization process with the server before logging off. Please wait for the current synchronization run to finish.</string>
 
     <string name="status_sent_description">This item has been successfully synchronized with the server.</string>
     <string name="status_offline_description">This item has not yet been synchronized with the server.</string>


### PR DESCRIPTION
Closes https://github.com/EyeSeeTea/dhis2-android-eventcapture/issues/67


This PR only solves the logout crash, but not infinite sync.

I can't replicate the infinite sync on current server. I think this problem could be related with unsupported types(added by the alpha testers) as @manuelplazaspalacio solved in: https://github.com/EyeSeeTea/dhis2-android-sdk/pull/201/commits/afa2e1113a670e9ebbab83d91d9975fd523936e4