### PR TITLE
ignore program rules without condition

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/controllers/metadata/MetaDataController.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/controllers/metadata/MetaDataController.java
@@ -956,7 +956,12 @@ public final class MetaDataController extends ResourceController {
                 .getLastUpdated(ResourceType.PROGRAMRULES);
         List<ProgramRule> programRules = unwrapResponse(dhisApi
                 .getProgramRules(getBasicQueryMap(lastUpdated)), ApiEndpointContainer.PROGRAMRULES);
-        saveResourceDataFromServer(ResourceType.PROGRAMRULES, dhisApi, programRules, getProgramRules(), serverDateTime);
+        List<ProgramRule> validProgramRules = new ArrayList<>();
+        for(ProgramRule programRule : programRules){
+            if(programRule.getCondition()!=null && programRule.getCondition().isEmpty())
+                validProgramRules.add(programRule);
+        }
+        saveResourceDataFromServer(ResourceType.PROGRAMRULES, dhisApi, validProgramRules, getProgramRules(), serverDateTime);
     }
 
     private static void getProgramRuleVariablesDataFromServer(DhisApi dhisApi, DateTime serverDateTime) throws APIException {


### PR DESCRIPTION
Closes https://github.com/EyeSeeTea/dhis2-android-trackercapture/issues/246

I can't replicate the problem using import/export. But i think i found the bugs.
Analysing the crashlytics log i see a crashes related with a empty program rule condition.

To test it, i created a program rule with action but without condition, and the app crash when i select the related program.