### PR TITLE
fix crash https://www.fabric.io/dhis2/android/apps/org.hisp.dhis.andr…

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/synchronization/domain/common/Synchronizer.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/synchronization/domain/common/Synchronizer.java
@@ -89,7 +89,6 @@ public class Synchronizer {
                 }
                 failedItem.setItemId(id);
                 failedItem.setItemType(type);
-                failedItem.setHttpStatusCode(apiException.getResponse().getStatus());
                 failedItem.setFailCount(failedItem.getFailCount() + 1);
                 mFailedItemRepository.save(failedItem);
             }


### PR DESCRIPTION
Closes https://github.com/EyeSeeTea/dhis2-android-trackercapture/issues/249

I removed the last setHttpStatusCode because could be null.
And is setted checking apiexception response null here: 
https://github.com/EyeSeeTea/dhis2-android-sdk/compare/tracker-capture...EyeSeeTea:feature-tracker-capture_crashlytics_bugs?expand=1#diff-493571ac4cc744f83f9c32f4f03f799cL81