### PR TITLE
fix null bug: when the enrollment haven't events the date should be null

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/utils/services/ProgramIndicatorService.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/utils/services/ProgramIndicatorService.java
@@ -445,7 +445,10 @@ public class ProgramIndicatorService {
                     } else if (ProgramIndicator.CURRENT_DATE.equals(uid)) {
                         date = currentDate;
                     } else if (ProgramIndicator.EVENT_DATE.equals(uid)) {
-                        date = DateUtils.parseDate(enrollmentProgramInstance.getEvents().get(0).getEventDate());
+                        if(enrollmentProgramInstance.getEvents().size()>0) {
+                            date = DateUtils.parseDate(
+                                    enrollmentProgramInstance.getEvents().get(0).getEventDate());
+                        }
                     }
 
                     if (date != null) {


### PR DESCRIPTION
Closes https://github.com/EyeSeeTea/dhis2-android-trackercapture/issues/253