### PR TITLE
Added org unit variable constants

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/utils/api/ContextVariableType.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/utils/api/ContextVariableType.java
@@ -39,6 +39,7 @@ public enum ContextVariableType {
     EVENT_ID( "event_id" ),
     INCIDENT_DATE( "incident_date" ),
     ENROLLMENT_COUNT( "enrollment_count" ),
+    ORG_UNIT_CODE( "orgunit_code" ),
     TEI_COUNT( "tei_count" );
 
     final String value;

--- a/core/src/main/java/org/hisp/dhis/android/sdk/utils/services/VariableService.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/utils/services/VariableService.java
@@ -29,7 +29,7 @@
 
 package org.hisp.dhis.android.sdk.utils.services;
 
-import android.util.Log;
+import static android.text.TextUtils.isEmpty;
 
 import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Select;
@@ -44,7 +44,6 @@ import org.hisp.dhis.android.sdk.persistence.models.Enrollment;
 import org.hisp.dhis.android.sdk.persistence.models.Event;
 import org.hisp.dhis.android.sdk.persistence.models.Option;
 import org.hisp.dhis.android.sdk.persistence.models.Option$Table;
-import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramRuleVariable;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttribute$Table;
@@ -61,8 +60,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static android.text.TextUtils.isEmpty;
 
 /**
  * Class for handling {@link ProgramRuleVariable}s that can be used in expressions of {@link org.hisp.dhis.android.sdk.persistence.models.ProgramIndicator}
@@ -874,6 +871,21 @@ public class VariableService {
                 }
                 break;
             }
+            case ORG_UNIT_CODE:
+                if (executingEnrollment != null) {
+                    programRuleVariable.setVariableValue(executingEnrollment.getOrgUnit());
+                    programRuleVariable.setHasValue(true);
+                    programRuleVariable.setVariableType(ValueType.TEXT);
+                } else if (executingEvent != null) {
+                    programRuleVariable.setVariableValue(executingEvent.getOrganisationUnitId());
+                    programRuleVariable.setHasValue(true);
+                    programRuleVariable.setVariableType(ValueType.TEXT);
+                } else {
+                    programRuleVariable.setHasValue(false);
+                    programRuleVariable.setVariableValue("");
+                    programRuleVariable.setVariableType(ValueType.TEXT);
+                }
+                break;
             case TEI_COUNT: {
                 if (executingEnrollment != null) {
                     programRuleVariable.setVariableValue("1");


### PR DESCRIPTION
Closes https://github.com/EyeSeeTea/dhis2-android-trackercapture/issues/305

Remember:
The string is V{orgunit_code} with V upper case.
The web program action field "Expression to evaluate and display after static text" is not shown in the app, we must ignore it.

I created some example program rules for the program MNCH / PNC (Adult woman) using the org unit code of Ngelehun CHC