### PR TITLE
Feature assess and fix program rules in eta program

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/adapters/rows/dataentry/DatePickerRow.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/adapters/rows/dataentry/DatePickerRow.java
@@ -175,7 +175,7 @@ public class DatePickerRow extends Row {
             dateSetListener.setBaseValue(baseValue);
             clearButtonListener.setBaseValue(baseValue);
 
-            if(baseValue !=null && baseValue.getValue()!=null && !baseValue.equals("")) {
+            if(baseValue !=null && baseValue.getValue()!=null && !baseValue.equals("") && !baseValue.getValue().isEmpty()) {
                 try {
                     Date date = new SimpleDateFormat("yyyy-MM-dd").parse(baseValue.getValue());
                     LocalDate currentDate = LocalDate.fromDateFields(date);

--- a/core/src/main/java/org/hisp/dhis/android/sdk/utils/services/VariableService.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/utils/services/VariableService.java
@@ -603,6 +603,7 @@ public class VariableService {
                         if (value == null) {
                             value = dataValue.getValue();
                         }
+                        value = getDataElementValue(programRuleVariable, value);
                         allValues.add(dataValue.getValue());
                     }
                 }
@@ -623,11 +624,13 @@ public class VariableService {
                                 if (value == null) {
                                     value = dataValue.getValue();
                                 }
+                                value = getDataElementValue(programRuleVariable, value);
                                 allValues.add(dataValue.getValue());
                             }
                         }
                         if (dataValue != null) {
                             value = dataValue.getValue();
+                            value = getDataElementValue(programRuleVariable, value);
                         } else {
                             DataElement dataElement = getInstance().getDataElementMap().get(programRuleVariable.getDataElement());
                             defaultValue = getDefaultValue(dataElement.getValueType());
@@ -658,6 +661,7 @@ public class VariableService {
                                 if (value == null) {
                                     value = dataValue.getValue();
                                 }
+                                value = getDataElementValue(programRuleVariable, value);
                                 allValues.add(dataValue.getValue());
                             }
                         }
@@ -679,7 +683,7 @@ public class VariableService {
                     }
                     TrackedEntityAttributeValue trackedEntityAttributeValue = getInstance().getTrackedEntityAttributeValueMap().get(programRuleVariable.getTrackedEntityAttribute());
                     if (trackedEntityAttributeValue != null) {
-                        value = trackedEntityAttributeValue.getValue();
+                        value = getTrackedEntityAttributeValue(trackedEntityAttributeValue.getTrackedEntityAttributeId(), trackedEntityAttributeValue.getValue());
                         allValues.add(value);
                     }
                 }
@@ -691,6 +695,7 @@ public class VariableService {
                     DataValue dataValue = getInstance().getEventDataValueMaps().get(getInstance().getCurrentEvent()).get(programRuleVariable.getDataElement());
                     if (dataValue != null) {
                         value = dataValue.getValue();
+                        value = getDataElementValue(programRuleVariable, value);
                         allValues.add(value);
                     }
                 }
@@ -714,6 +719,44 @@ public class VariableService {
         programRuleVariable.setAllValues(allValues);
     }
 
+
+    /**
+     * Returns the option code of a data element if exists, either returns the given value.
+     *
+     * @return
+     */
+    private static String getDataElementValue(ProgramRuleVariable programRuleVariable, String value) {
+        DataElement dataElement = MetaDataController.getDataElement(programRuleVariable.getDataElement());
+        if(dataElement!=null) {
+            String optionSet = dataElement.getOptionSet();
+            List<Option> options = MetaDataController.getOptions(optionSet);
+            for (Option option : options) {
+                if(option.getName().equals(value)) {
+                    value = option.getCode();
+                }
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Returns the option code of a tracked entity attribute if exists, either returns the given value.
+     *
+     * @return
+     */
+    private static String getTrackedEntityAttributeValue(String trackedEntityAttributeUId, String value) {
+        TrackedEntityAttribute trackedEntityAttribute = MetaDataController.getTrackedEntityAttribute(trackedEntityAttributeUId);
+        if(trackedEntityAttribute!=null) {
+            String optionSet = trackedEntityAttribute.getOptionSet();
+            List<Option> options = MetaDataController.getOptions(optionSet);
+            for (Option option : options) {
+                if(option.getName().equals(value)) {
+                    value = option.getCode();
+                }
+            }
+        }
+        return value;
+    }
     /**
      * Returns a list of populated {@link ProgramRuleVariable}s based on all {@link Constant}
      * currently stored in the database.


### PR DESCRIPTION
Closes https://github.com/EyeSeeTea/dhis2-android-trackercapture/issues/310


Fixed core/extended rules, when a evaluated value is an option the app search the option code from the datavalue or trackedentityatrribute.

Pending:
The edit profile fragment is not applying the program rules.

For eta program:

Some rules with a not filled dataelement not works and some program stages still hidden when should be shown.