### PR TITLE
Feature add mehods to retrieve specific programs

### DIFF
--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/api/network/NetworkModuleImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/api/network/NetworkModuleImpl.java
@@ -130,9 +130,9 @@ public class NetworkModuleImpl implements NetworkModule {
     private static final SimpleDateFormat DATE_FORMAT =
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
 
-    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 15 * 1000;   // 15s
-    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 20 * 1000;      // 20s
-    private static final int DEFAULT_WRITE_TIMEOUT_MILLIS = 20 * 1000;     // 20s
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 30 * 1000;   // 30s
+    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 30 * 1000;      // 30s
+    private static final int DEFAULT_WRITE_TIMEOUT_MILLIS = 30 * 1000;     // 30s
 
     private final OrganisationUnitApiClient organisationUnitApiClient;
     private final AttributeApiClient attributeApiClient;

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/UserProgramInteractor.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/UserProgramInteractor.java
@@ -51,5 +51,8 @@ public interface UserProgramInteractor {
 
     Observable<List<Program>> list(Set<ProgramType> programTypes);
 
+    Observable<List<Program>> list(OrganisationUnit organisationUnit, Set<ProgramType> programTypes,
+            String attributeCode, String attributeValue);
+
     Observable<List<Program>> list(List<OrganisationUnit> organisationUnits);
 }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/UserProgramInteractorImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/UserProgramInteractorImpl.java
@@ -95,6 +95,20 @@ public class UserProgramInteractorImpl implements UserProgramInteractor {
     }
 
     @Override
+    public Observable<List<Program>> list(final OrganisationUnit organisationUnit,
+            final Set<ProgramType> programTypes, final String attributeCode,
+            final String attributeValue) {
+        return Observable.create(new DefaultOnSubscribe<List<Program>>() {
+
+            @Override
+            public List<Program> call() {
+                return programService.list(organisationUnit, true, programTypes,
+                        attributeCode, attributeValue);
+            }
+        });
+    }
+
+    @Override
     public Observable<List<Program>> list(final List<OrganisationUnit> organisationUnits) {
         return Observable.create(new DefaultOnSubscribe<List<Program>>() {
 

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramService.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramService.java
@@ -47,5 +47,8 @@ public interface ProgramService extends Service, Get<Program>, GetUid<Program>,
 
     List<Program> list(boolean assignedToCurrentUser, Set<ProgramType> programTypes);
 
+    List<Program> list(OrganisationUnit organisationUnit, boolean assignedToCurrentUser,
+            Set<ProgramType> programTypes, String attributeCode, String attributeValue);
+
     List<Program> list(List<OrganisationUnit> organisationUnits);
 }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramServiceImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramServiceImpl.java
@@ -68,6 +68,13 @@ public final class ProgramServiceImpl implements ProgramService {
     }
 
     @Override
+    public List<Program> list(OrganisationUnit organisationUnit, boolean assignedToCurrentUser,
+            Set<ProgramType> programTypes, String attributeCode, String attributeValue) {
+        return programStore.query(organisationUnit, assignedToCurrentUser, programTypes,
+                attributeCode, attributeValue);
+    }
+
+    @Override
     public List<Program> list(List<OrganisationUnit> organisationUnits) {
         return programStore.query(organisationUnits);
     }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramStore.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramStore.java
@@ -41,5 +41,8 @@ public interface ProgramStore extends IdentifiableObjectStore<Program> {
 
     List<Program> query(boolean assignedToCurrentUser, Set<ProgramType> programType);
 
+    List<Program> query(OrganisationUnit organisationUnit, boolean assignedToCurrentUser, Set<ProgramType> programType,
+            String attributeCode, String attributeValue);
+
     List<Program> query(List<OrganisationUnit> units);
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/1904
* **Related pull-requests:** https://github.com/EyeSeeTea/malariapp/pull/2029

### :tophat: What is the goal?

The goal is to create a new method to retrieve programs from dhis2 api with specific filters avoiding create specific queries from outside of SDK.
This new method is used by HNQIS app to retrieve HNQIS programs during pull process.

### :memo: How is it being implemented?

I have created new method list in program classes and using one unique query to retrieve programs.

### :boom: How can it be tested?

 **Use case 1:** Realize a pull in HNQIS and the app should work.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-