### PR TITLE
Update me endpoint to 2.30 api version

### DIFF
--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/UserAccountApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/UserAccountApiClientImpl.java
@@ -28,13 +28,13 @@
 
 package org.hisp.dhis.client.sdk.android.user;
 
+import static org.hisp.dhis.client.sdk.android.api.network.NetworkUtils.call;
+
 import org.hisp.dhis.client.sdk.core.user.UserApiClient;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.hisp.dhis.client.sdk.android.api.network.NetworkUtils.call;
 
 public class UserAccountApiClientImpl implements UserApiClient {
     private final UserApiClientRetrofit apiClient;
@@ -44,14 +44,14 @@ public class UserAccountApiClientImpl implements UserApiClient {
     }
 
     @Override
-    public UserAccount getUserAccount() {
+    public UserAccount getUserAccount(int apiVersion) {
         Map<String, String> QUERY_PARAMS = new HashMap<>();
         QUERY_PARAMS.put("fields", "id,created,lastUpdated,name,displayName," +
                 "firstName,surname,gender,birthday,introduction," +
                 "education,employer,interests,jobTitle,languages,email,phoneNumber," +
-                "organisationUnits[id],userCredentials[userRoles[dataSets[id],programs[id,programType]]]");
+                "organisationUnits[id,programs[id,programType]],userCredentials[userRoles], programs, dataSets");
 
-        return call(apiClient.getCurrentUserAccount(QUERY_PARAMS));
+        return call(apiClient.getCurrentUserAccount(apiVersion, QUERY_PARAMS));
     }
 
     @Override

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/UserApiClientRetrofit.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/UserApiClientRetrofit.java
@@ -33,11 +33,11 @@ import org.hisp.dhis.client.sdk.models.user.UserAccount;
 
 import java.util.Map;
 
-import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
 import retrofit2.http.QueryMap;
 
 public interface UserApiClientRetrofit {
@@ -46,8 +46,9 @@ public interface UserApiClientRetrofit {
     // Methods for getting user information
     /////////////////////////////////////////////////////////////////////////
 
-    @GET("me/")
-    Call<UserAccount> getCurrentUserAccount(@QueryMap Map<String, String> queryParams);
+    @GET("{apiVersion}/me")
+    Call<UserAccount> getCurrentUserAccount(@Path("apiVersion") int apiVersion,
+            @QueryMap Map<String, String> queryParams);
 
     @POST("me/profile")
     Call<Void> postCurrentUserAccount(@Body UserAccount userAccount);

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/common/controllers/ControllersModuleImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/common/controllers/ControllersModuleImpl.java
@@ -183,7 +183,7 @@ public class ControllersModuleImpl implements ControllersModule {
                 preferencesModule.getLastUpdatedPreferences(),
                 persistenceModule.getTransactionManager());
 
-        assignedProgramsController = new AssignedProgramsControllerImpl(
+        assignedProgramsController = new AssignedProgramsControllerImpl(systemInfoController,
                 programControllerImpl, networkModule.getUserApiClient());
 
         organisationUnitController = new OrganisationUnitControllerImpl(
@@ -202,9 +202,10 @@ public class ControllersModuleImpl implements ControllersModule {
                 persistenceModule.getTransactionManager());
 
         assignedOrganisationUnitsController = new AssignedOrganisationUnitControllerImpl(
-                organisationUnitController, networkModule.getUserApiClient());
+                systemInfoController, organisationUnitController, networkModule.getUserApiClient());
 
         userAccountController = new UserAccountControllerImpl(
+                systemInfoController,
                 networkModule.getUserApiClient(),
                 persistenceModule.getUserAccountStore(),
                 persistenceModule.getAttributeValueStore(),

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/organisationunit/OrganisationUnitControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/organisationunit/OrganisationUnitControllerImpl.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.client.sdk.core.common.utils.ModelUtils;
 import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.core.user.UserApiClient;
 import org.hisp.dhis.client.sdk.models.attribute.AttributeValue;
+import org.hisp.dhis.client.sdk.models.common.SystemInfo;
 import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnit;
 import org.joda.time.DateTime;
 
@@ -84,7 +85,8 @@ public class OrganisationUnitControllerImpl extends AbsSyncStrategyController<Or
 
     @Override
     protected void synchronize(SyncStrategy strategy, Set<String> uids) {
-        DateTime serverTime = systemInfoController.getSystemInfo().getServerDate();
+        SystemInfo systemInfo = systemInfoController.getSystemInfo();
+        DateTime serverTime = systemInfo.getServerDate();
         DateTime lastUpdated = lastUpdatedPreferences.get(
                 ResourceType.ORGANISATION_UNITS, DateType.SERVER);
 
@@ -122,7 +124,8 @@ public class OrganisationUnitControllerImpl extends AbsSyncStrategyController<Or
 
         // we need to mark assigned organisation units as "assigned" before storing them
         Map<String, OrganisationUnit> assignedOrganisationUnits = ModelUtils
-                .toMap(userApiClient.getUserAccount().getOrganisationUnits());
+                .toMap(userApiClient.getUserAccount(systemInfo.getApiVersion())
+                        .getOrganisationUnits());
 
         for (OrganisationUnit updatedOrganisationUnit : updatedOrganisationUnits) {
             OrganisationUnit assignedOrganisationUnit = assignedOrganisationUnits
@@ -156,7 +159,8 @@ public class OrganisationUnitControllerImpl extends AbsSyncStrategyController<Or
     @Override
     public List<OrganisationUnit> pullAllDescendants(SyncStrategy strategy, String uid)
             throws ApiException {
-        DateTime serverTime = systemInfoController.getSystemInfo().getServerDate();
+        SystemInfo systemInfo = systemInfoController.getSystemInfo();
+        DateTime serverTime = systemInfo.getServerDate();
         DateTime lastUpdated = lastUpdatedPreferences.get(
                 ResourceType.ORGANISATION_UNITS, DateType.SERVER);
 
@@ -183,7 +187,8 @@ public class OrganisationUnitControllerImpl extends AbsSyncStrategyController<Or
 
         // we need to mark assigned organisation units as "assigned" before storing them
         Map<String, OrganisationUnit> assignedOrganisationUnits = ModelUtils
-                .toMap(userApiClient.getUserAccount().getOrganisationUnits());
+                .toMap(userApiClient.getUserAccount(systemInfo.getApiVersion())
+                        .getOrganisationUnits());
 
         for (OrganisationUnit updatedOrganisationUnit : updatedOrganisationUnits) {
             OrganisationUnit assignedOrganisationUnit = assignedOrganisationUnits

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramControllerImpl.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.core.trackedentity.TrackedEntityController;
 import org.hisp.dhis.client.sdk.core.user.UserApiClient;
 import org.hisp.dhis.client.sdk.models.attribute.AttributeValue;
+import org.hisp.dhis.client.sdk.models.common.SystemInfo;
 import org.hisp.dhis.client.sdk.models.dataelement.DataElement;
 import org.hisp.dhis.client.sdk.models.optionset.Option;
 import org.hisp.dhis.client.sdk.models.optionset.OptionSet;
@@ -138,7 +139,8 @@ public class ProgramControllerImpl extends
     }
 
     private void synchronizeByLastUpdated(Set<String> uids) {
-        DateTime serverTime = systemInfoController.getSystemInfo().getServerDate();
+        SystemInfo systemInfo = systemInfoController.getSystemInfo();
+        DateTime serverTime = systemInfo.getServerDate();
         DateTime lastUpdated = lastUpdatedPreferences.get(ResourceType.PROGRAMS, DateType.SERVER);
 
         List<Program> persistedPrograms = identifiableObjectStore.queryAll();
@@ -172,7 +174,7 @@ public class ProgramControllerImpl extends
         // we need to mark assigned programs as "assigned" before storing them
         // TODO remove this call (additional request which performs check if user is assigned)
         Map<String, Program> assignedPrograms = toMap(userApiClient
-                .getUserAccount().getPrograms());
+                .getUserAccount(systemInfo.getApiVersion()).getPrograms());
 
         for (Program updatedProgram : updatedPrograms) {
             Program assignedProgram = assignedPrograms.get(updatedProgram.getUId());
@@ -274,7 +276,7 @@ public class ProgramControllerImpl extends
 
         // we need to mark assigned programs as "assigned" before storing them
         Map<String, Program> assignedPrograms = toMap(userApiClient
-                .getUserAccount().getPrograms());
+                .getUserAccount(systemInfoController.getSystemInfo().getApiVersion()).getPrograms());
 
         for (Program updatedProgram : updatedPrograms) {
             Program assignedProgram = assignedPrograms.get(updatedProgram.getUId());

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/user/AssignedOrganisationUnitControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/user/AssignedOrganisationUnitControllerImpl.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.client.sdk.core.common.controllers.SyncStrategy;
 import org.hisp.dhis.client.sdk.core.common.network.ApiException;
 import org.hisp.dhis.client.sdk.core.common.utils.ModelUtils;
 import org.hisp.dhis.client.sdk.core.organisationunit.OrganisationUnitController;
+import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnit;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
 
@@ -40,6 +41,7 @@ import java.util.Set;
 
 public class AssignedOrganisationUnitControllerImpl implements AssignedOrganisationUnitsController {
 
+    private final SystemInfoController systemInfoController;
     // Api Clients
     private final UserApiClient userApiClient;
 
@@ -47,7 +49,9 @@ public class AssignedOrganisationUnitControllerImpl implements AssignedOrganisat
     private final OrganisationUnitController organisationUnitController;
 
     public AssignedOrganisationUnitControllerImpl(
+            SystemInfoController systemInfoController,
             OrganisationUnitController organisationUnitController, UserApiClient userApiClient) {
+        this.systemInfoController = systemInfoController;
         this.userApiClient = userApiClient;
         this.organisationUnitController = organisationUnitController;
     }
@@ -59,7 +63,8 @@ public class AssignedOrganisationUnitControllerImpl implements AssignedOrganisat
 
     @Override
     public void sync(SyncStrategy strategy) throws ApiException {
-        UserAccount userAccount = userApiClient.getUserAccount();
+        UserAccount userAccount = userApiClient.getUserAccount(
+                systemInfoController.getSystemInfo().getApiVersion());
 
         /* get list of assigned organisation units */
         List<OrganisationUnit> assignedOrganisationUnits = userAccount.getOrganisationUnits();

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/user/AssignedProgramsControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/user/AssignedProgramsControllerImpl.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.client.sdk.core.common.network.ApiException;
 import org.hisp.dhis.client.sdk.core.common.utils.ModelUtils;
 import org.hisp.dhis.client.sdk.core.program.ProgramController;
 import org.hisp.dhis.client.sdk.core.program.ProgramFields;
+import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.models.program.Program;
 import org.hisp.dhis.client.sdk.models.program.ProgramType;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
@@ -48,14 +49,19 @@ import static org.hisp.dhis.client.sdk.utils.Preconditions.isNull;
  */
 public class AssignedProgramsControllerImpl implements AssignedProgramsController {
 
+    private final SystemInfoController systemInfoController;
+
     /* Program controller */
     private final ProgramController programController;
 
     /* Api clients */
     private final UserApiClient userApiClient;
 
-    public AssignedProgramsControllerImpl(ProgramController programController,
-                                          UserApiClient userApiClient) {
+    public AssignedProgramsControllerImpl(
+            SystemInfoController systemInfoController,
+            ProgramController programController,
+            UserApiClient userApiClient) {
+        this.systemInfoController = systemInfoController;
         this.userApiClient = userApiClient;
         this.programController = programController;
     }
@@ -74,7 +80,8 @@ public class AssignedProgramsControllerImpl implements AssignedProgramsControlle
             throw new IllegalArgumentException("Specify at least one ProgramType");
         }
 
-        UserAccount userAccount = userApiClient.getUserAccount();
+        UserAccount userAccount = userApiClient.getUserAccount(
+                systemInfoController.getSystemInfo().getApiVersion());
 
         /* get list of assigned programs */
         List<Program> assignedPrograms = userAccount.getPrograms();

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/user/UserAccountControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/user/UserAccountControllerImpl.java
@@ -31,22 +31,18 @@ package org.hisp.dhis.client.sdk.core.user;
 import org.hisp.dhis.client.sdk.core.attribute.AttributeValueStore;
 import org.hisp.dhis.client.sdk.core.common.StateStore;
 import org.hisp.dhis.client.sdk.core.common.network.ApiException;
-import org.hisp.dhis.client.sdk.core.common.persistence.DbOperation;
-import org.hisp.dhis.client.sdk.core.common.persistence.DbOperationImpl;
-import org.hisp.dhis.client.sdk.core.common.persistence.DbUtils;
 import org.hisp.dhis.client.sdk.core.common.persistence.TransactionManager;
-import org.hisp.dhis.client.sdk.models.attribute.AttributeValue;
+import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.models.common.state.Action;
-import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnit;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
 import org.hisp.dhis.client.sdk.utils.Logger;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public final class UserAccountControllerImpl implements UserAccountController {
     private static final String TAG = UserAccountControllerImpl.class.getSimpleName();
 
+    private final SystemInfoController systemInfoController;
     private final UserApiClient userApiClient;
     private final UserAccountStore userAccountStore;
     private final StateStore stateStore;
@@ -55,11 +51,14 @@ public final class UserAccountControllerImpl implements UserAccountController {
     private final AttributeValueStore attributeValueStore;
     private final TransactionManager transactionManager;
 
-    public UserAccountControllerImpl(UserApiClient userApiClient,
-                                     UserAccountStore userAccountStore,
-                                     AttributeValueStore attributeValueStore,
-                                     TransactionManager transactionManager,
-                                     StateStore stateStore, Logger logger) {
+    public UserAccountControllerImpl(
+            SystemInfoController systemInfoController,
+            UserApiClient userApiClient,
+            UserAccountStore userAccountStore,
+            AttributeValueStore attributeValueStore,
+            TransactionManager transactionManager,
+            StateStore stateStore, Logger logger) {
+        this.systemInfoController = systemInfoController;
         this.userApiClient = userApiClient;
         this.userAccountStore = userAccountStore;
         this.attributeValueStore = attributeValueStore;
@@ -70,7 +69,8 @@ public final class UserAccountControllerImpl implements UserAccountController {
 
     @Override
     public void pull() throws ApiException {
-        UserAccount userAccount = userApiClient.getUserAccount();
+        UserAccount userAccount = userApiClient.getUserAccount(
+                systemInfoController.getSystemInfo().getApiVersion());
 
         // update userAccount in database
         userAccountStore.save(userAccount);

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/user/UserApiClient.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/user/UserApiClient.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.client.sdk.core.user;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
 
 public interface UserApiClient {
-    UserAccount getUserAccount();
+    UserAccount getUserAccount(int apiVersion);
 
     void postUserAccount(UserAccount userAccount);
 }

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/SystemInfo.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/SystemInfo.java
@@ -33,6 +33,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.joda.time.DateTime;
 
+import java.util.regex.Pattern;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class SystemInfo {
 
@@ -56,6 +58,8 @@ public final class SystemInfo {
 
     @JsonProperty("version")
     String version;
+
+    private static final int latestSupportedAPIVersion = 30;
 
     public SystemInfo() {
         // explicit empty constructor
@@ -115,5 +119,15 @@ public final class SystemInfo {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public int getApiVersion() {
+        String[] completedVersionParts = version.split(Pattern.quote("."));
+        int serverVersion = Integer.parseInt(completedVersionParts[1]);
+
+        if (serverVersion > latestSupportedAPIVersion)
+            return latestSupportedAPIVersion;
+        else
+            return serverVersion;
     }
 }

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/SystemInfo.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/SystemInfo.java
@@ -59,7 +59,8 @@ public final class SystemInfo {
     @JsonProperty("version")
     String version;
 
-    private static final int latestSupportedAPIVersion = 30;
+    public static final int maxSupportedAPIVersion = 30;
+    public static final int minSupportedAPIVersion = 26;
 
     public SystemInfo() {
         // explicit empty constructor
@@ -122,12 +123,19 @@ public final class SystemInfo {
     }
 
     public int getApiVersion() {
-        String[] completedVersionParts = version.split(Pattern.quote("."));
-        int serverVersion = Integer.parseInt(completedVersionParts[1]);
+        if (version != null) {
+            String[] completedVersionParts = version.split(Pattern.quote("."));
+            int serverVersion = Integer.parseInt(completedVersionParts[1]);
 
-        if (serverVersion > latestSupportedAPIVersion)
-            return latestSupportedAPIVersion;
-        else
-            return serverVersion;
+            if (serverVersion < minSupportedAPIVersion)
+                throw new UnsupportedServerVersionException(serverVersion, minSupportedAPIVersion);
+
+            if (serverVersion > maxSupportedAPIVersion)
+                return maxSupportedAPIVersion;
+            else
+                return serverVersion;
+        } else {
+            return minSupportedAPIVersion;
+        }
     }
 }

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/UnsupportedServerVersionException.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/UnsupportedServerVersionException.java
@@ -1,0 +1,9 @@
+package org.hisp.dhis.client.sdk.models.common;
+
+public class UnsupportedServerVersionException extends RuntimeException {
+    public UnsupportedServerVersionException(int serverVersion, int minApiVersion) {
+        super(String.format(
+                "The server version %d is not supported. Minimum server version supported is %d",
+                serverVersion, minApiVersion));
+    }
+}

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/user/UserRole.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/user/UserRole.java
@@ -31,37 +31,16 @@ package org.hisp.dhis.client.sdk.models.user;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.hisp.dhis.client.sdk.models.common.base.BaseIdentifiableObject;
 import org.hisp.dhis.client.sdk.models.dataset.DataSet;
 import org.hisp.dhis.client.sdk.models.program.Program;
 
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class UserRole {
-
-    @JsonProperty("programs")
-    List<Program> programs;
-
-    @JsonProperty("dataSets")
-    List<DataSet> dataSets;
+class UserRole extends BaseIdentifiableObject {
 
     public UserRole() {
         // explicit empty constructor
-    }
-
-    public List<Program> getPrograms() {
-        return programs;
-    }
-
-    public void setPrograms(List<Program> programs) {
-        this.programs = programs;
-    }
-
-    public List<DataSet> getDataSets() {
-        return dataSets;
-    }
-
-    public void setDataSets(List<DataSet> dataSets) {
-        this.dataSets = dataSets;
     }
 }

--- a/models/src/test/java/org/hisp/dhis/client/sdk/models/common/SystemInfoShould.java
+++ b/models/src/test/java/org/hisp/dhis/client/sdk/models/common/SystemInfoShould.java
@@ -1,0 +1,46 @@
+package org.hisp.dhis.client.sdk.models.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SystemInfoShould {
+
+    @Rule
+    public ExpectedException mExpectedException = ExpectedException.none();
+
+    @Test
+    public void return_min_api_version_if_server_version_is_empty() {
+        SystemInfo systemInfo = new SystemInfo();
+
+        assertThat(systemInfo.getApiVersion(),is(SystemInfo.minSupportedAPIVersion));
+    }
+
+    @Test
+    public void throw_unsupported_server_exception_if_server_version_is_smaller_than_min() {
+        mExpectedException.expect(UnsupportedServerVersionException.class);
+        SystemInfo systemInfo = new SystemInfo();
+        systemInfo.version = "2." + (SystemInfo.minSupportedAPIVersion - 6);;
+
+        systemInfo.getApiVersion();
+    }
+
+    @Test
+    public void return_max_api_version_if_server_version_greater_than_max() {
+        SystemInfo systemInfo = new SystemInfo();
+        systemInfo.version = "2." + (SystemInfo.maxSupportedAPIVersion + 1);
+
+        assertThat(systemInfo.getApiVersion(),is(SystemInfo.maxSupportedAPIVersion));
+    }
+
+    @Test
+    public void return_expected_api_version_if_server_version_is_between_thresholds() {
+        SystemInfo systemInfo = new SystemInfo();
+        systemInfo.version = "2." + (SystemInfo.maxSupportedAPIVersion - 1);
+
+        assertThat(systemInfo.getApiVersion(),is(SystemInfo.maxSupportedAPIVersion - 1));
+    }
+}


### PR DESCRIPTION
 ### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2074
* **Related pull-requests:** https://github.com/EyeSeeTea/malariapp/pull/2084

### :tophat: What is the goal?

The goal is to upgrade to 2.30 version the EyeSeeTea Dhis SDK.

This PR contains the upgrade to 2.30 the /me endpoint.

### :memo: How is it being implemented?

I have updated the request, response models. I have added API version parameter in /me request and logic to calculate it in SystemInfo model:
The max supported API version from now is 2.30 and min supported API version is 2.26 then:
 - if the server is smaller then 2.26 then we throw UnSupportedServerVersionException (API version parameter is valid from 2.26).
 - if the server is greater than 2.30 then API version to use is 2.30 else we use server version like API version.

### :boom: How can it be tested?

- [x] **Use case 1:** Execute SystemInfoShould unit tests
- [x] **Use case 2:** Realize login against https://data.psi-mis.org (2.25), then login should fail and show unsupported server version message.
- [ ] **Use case 2:** Realize login against https://latest.psi-mis.org (2.30) then login should work and navigate to InProgress activity, finally the pull of metadata fail when is realizing the request 
https://latest.psi-mis.org/api/programStageDataElements?paging=false&fields=id but this error will be fixed in the next issue.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

