### PR TITLE
Feature upgrade to 2 30 fix program stage data element request

### DIFF
--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramStageDataElementApiClientRetrofit.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramStageDataElementApiClientRetrofit.java
@@ -29,7 +29,7 @@
 package org.hisp.dhis.client.sdk.android.program;
 
 
-import org.hisp.dhis.client.sdk.models.program.ProgramStageDataElement;
+import org.hisp.dhis.client.sdk.models.program.Program;
 
 import java.util.List;
 import java.util.Map;
@@ -40,7 +40,7 @@ import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 
 public interface ProgramStageDataElementApiClientRetrofit {
-    @GET("programStageDataElements")
-    Call<Map<String, List<ProgramStageDataElement>>> getProgramStageDataElements(
+    @GET("programs")
+    Call<Map<String, List<Program>>> getProgramStageDataElements(
             @QueryMap Map<String, String> queryMap, @Query("filter") List<String> filters);
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2094
* **Related pull-requests:** 

### :tophat: What is the goal?

The goal is to upgrade to 2.30 version the EyeSeeTea Dhis SDK.

This PR contains the upgrade to 2.30 the /programStageDataElements?fields=id&paging=false endpoint.

### :memo: How is it being implemented?

This /programStageDataElements endpoint does not exist in 2.30, this endpoint was used to download all programStageDataElements with its id to compare with programStageDataElements obtained in /program endpoint.
I have refactored this request to download programStageDataElements via /program endpoint, example with id field:
https://latest.psi-mis.org/api/programs?fields=programStages[programStageDataElements[id]]&paging=false

This change in request require to refactor ProgramStageDataElementApiClientImpl because before retrofit client returned List<ProgramStageDataElement> and now return List<Program> and we have navigate to downloaded programs to extract ProgramStageDataElements.

Previously ProgramStageDataElementApiClientImpl was used getCollection method in NetworkUtils class but this only works for simple and standard scenarios, now I have needed to realize the call to retrofit client manually like in EventApiClientImpl to extract ProgramStageDataElements from programs after retrofit client response.

### :boom: How can it be tested?

- [x] **Use case 1:** Realize login against https://latest.psi-mis.org (2.30) then login should work and navigate to InProgress activity, the download metadata should work realizing all request but finally the metadata conversion fail. I think that this problem is because of the request https://latest.psi-mis.org/api/programStageSections?fields=id,programStageDataElements[id]&paging=false does not return associated ProgramStageDataElements to every ProgramStageSection but this error will be fixed in the next issue.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

