### PR TITLE
Feature upgrade to 2 30 fix program stage section request

### DIFF
--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramApiClientImpl.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.client.sdk.android.program;
 import org.hisp.dhis.client.sdk.android.api.network.ApiResource;
 import org.hisp.dhis.client.sdk.core.common.Fields;
 import org.hisp.dhis.client.sdk.core.common.network.ApiException;
+import org.hisp.dhis.client.sdk.core.dataelement.DataElementApiClient;
 import org.hisp.dhis.client.sdk.core.program.ProgramApiClient;
 import org.hisp.dhis.client.sdk.models.optionset.Option;
 import org.hisp.dhis.client.sdk.models.optionset.OptionSet;
@@ -38,8 +39,11 @@ import org.hisp.dhis.client.sdk.models.program.Program;
 import org.hisp.dhis.client.sdk.models.program.ProgramStage;
 import org.hisp.dhis.client.sdk.models.program.ProgramStageDataElement;
 import org.hisp.dhis.client.sdk.models.program.ProgramStageSection;
+import org.hisp.dhis.client.sdk.models.dataelement.DataElement;
 import org.joda.time.DateTime;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,31 +88,52 @@ public class ProgramApiClientImpl implements ProgramApiClient {
             @Override
             public String getDescendantProperties() {
                 return IDENTIFIABLE_PROPERTIES + "," + ATTRIBUTEVALUES_PROPERTIES
-                        + ",version,programType,organisationUnits[id],trackedEntity[" + IDENTIFIABLE_PROPERTIES + "]," +
-                        "programTrackedEntityAttributes[" + IDENTIFIABLE_PROPERTIES + ",mandatory," + // start programTrackedEntityAttributes
-                        "displayShortName,externalAccess,valueType,allowFutureDate,displayInList,program[id]," +
-                        "trackedEntityAttribute[" + IDENTIFIABLE_PROPERTIES + ",unique,programScope," + // start trackedEntityAttribute of parent programTrackedEntityAttributes
-                        "orgunitScope,displayInListNoProgram,displayOnVisitSchedule,externalAccess," +
-                        "valueType,confidential,inherit,sortOrderVisitSchedule,dimension,sortOrderInListNoProgram," +
-                        "optionSet[" + IDENTIFIABLE_PROPERTIES + ",version,options[" + IDENTIFIABLE_PROPERTIES + ",code]]]]" + //end programTrackedEntityAttributes
+                        + ",version,programType,organisationUnits[id],trackedEntity["
+                        + IDENTIFIABLE_PROPERTIES + "]," +
+                        "programTrackedEntityAttributes[" + IDENTIFIABLE_PROPERTIES + ",mandatory,"
+                        + // start programTrackedEntityAttributes
+                        "displayShortName,externalAccess,valueType,allowFutureDate,displayInList,"
+                        + "program[id],"
+                        +
+                        "trackedEntityAttribute[" + IDENTIFIABLE_PROPERTIES
+                        + ",unique,programScope," +
+                        // start trackedEntityAttribute of parent programTrackedEntityAttributes
+                        "orgunitScope,displayInListNoProgram,displayOnVisitSchedule,externalAccess,"
+                        +
+                        "valueType,confidential,inherit,sortOrderVisitSchedule,dimension,"
+                        + "sortOrderInListNoProgram,"
+                        +
+                        "optionSet[" + IDENTIFIABLE_PROPERTIES + ",version,options["
+                        + IDENTIFIABLE_PROPERTIES + ",code]]]]" +
+                        //end programTrackedEntityAttributes
                         ",displayFrontPageList,useFirstStageDuringRegistration," +
-                        "selectEnrollmentDatesInFuture,incidentDateLabel,selectIncidentDatesInFuture," +
-                        "onlyEnrollOnce,enrollmentDateLabel,ignoreOverdueEvents,displayIncidentDate," +
+                        "selectEnrollmentDatesInFuture,incidentDateLabel,"
+                        + "selectIncidentDatesInFuture,"
+                        +
+                        "onlyEnrollOnce,enrollmentDateLabel,ignoreOverdueEvents,"
+                        + "displayIncidentDate,"
+                        +
                         "withoutRegistration,registration,relationshipFromA," +
-                        "programStages[" + IDENTIFIABLE_PROPERTIES + ",dataEntryType," + // start programStages
+                        "programStages[" + IDENTIFIABLE_PROPERTIES + ",dataEntryType," +
+                        // start programStages
                         "blockEntryForm,reportDateDescription,executionDateLabel," +
                         "displayGenerateEventBox,description,externalAccess,openAfterEnrollment," +
                         "captureCoordinates,defaultTemplateMessage,remindCompleted," +
                         "validCompleteOnly,sortOrder,generatedByEnrollmentDate,preGenerateUID," +
                         "autoGenerateEvent,allowGenerateNextVisit,repeatable,minDaysFromStart," +
-                        "program[id],programStageSections[" + IDENTIFIABLE_PROPERTIES + ",sortOrder," + // start programStageSections of parent programStages
-                        "programStage[id],programStageDataElements[id]" + "]," +
-                        "programStageDataElements[" + IDENTIFIABLE_PROPERTIES + ",programStage[id]," + // start programStageDataElements of parent programStageSections
+                        "program[id],programStageSections[" + IDENTIFIABLE_PROPERTIES
+                        + ",sortOrder," + // start programStageSections of parent programStages
+                        "programStage[id],dataElements[id]" + "]," +
+                        "programStageDataElements[" + IDENTIFIABLE_PROPERTIES + ",programStage[id],"
+                        + // start programStageDataElements of parent programStageSections
                         "allowFutureDate,sortOrder,displayInReports,allowProvidedElsewhere," +
-                        "compulsory,dataElement[code,description," +ATTRIBUTEVALUES_PROPERTIES + "," +
-                        IDENTIFIABLE_PROPERTIES + "shortName,valueType," + // start dataElement of parent programStageDataElements
+                        "compulsory,dataElement[code,description," + ATTRIBUTEVALUES_PROPERTIES
+                        + "," +
+                        IDENTIFIABLE_PROPERTIES + "shortName,valueType," +
+                        // start dataElement of parent programStageDataElements
                         "zeroIsSignificant,aggregationOperator,formName,numberType,domainType," +
-                        "dimension,displayFormName,optionSet[" + IDENTIFIABLE_PROPERTIES + // start optionSet of parent dataElement
+                        "dimension,displayFormName,optionSet[" + IDENTIFIABLE_PROPERTIES +
+                        // start optionSet of parent dataElement
                         ",version,options[" + IDENTIFIABLE_PROPERTIES + ",code]]]]]"; // end
             }
 
@@ -121,25 +146,46 @@ public class ProgramApiClientImpl implements ProgramApiClient {
 
         List<Program> programs = getCollection(apiResource, fields, lastUpdated, uids);
 
+
         for (Program program : programs) {
             if (program.getProgramStages() != null && !program.getProgramStages().isEmpty()) {
                 for (ProgramStage programStage : program.getProgramStages()) {
-                    if (programStage.getProgramStageSections() != null && !programStage.getProgramStageSections().isEmpty()) {
-                        for (ProgramStageSection programStageSection : programStage.getProgramStageSections()) {
-                            if (programStageSection.getProgramStageDataElements() != null && !programStageSection.getProgramStageDataElements().isEmpty()) {
-                                for (int i = 0; i < programStageSection.getProgramStageDataElements().size(); i++) {
-                                    ProgramStageDataElement programStageDataElement = programStageSection.getProgramStageDataElements().get(i);
-                                    programStageDataElement.setSortOrderWithinProgramStageSection(i);
+                    if (programStage.getProgramStageSections() != null
+                            && !programStage.getProgramStageSections().isEmpty()) {
+                        for (ProgramStageSection programStageSection : programStage
+                                .getProgramStageSections()) {
+
+                            AssignProgramStageDataElementToSections(programStageSection,
+                                    programStage.getProgramStageDataElements());
+
+                            if (programStageSection.getProgramStageDataElements() != null
+                                    && !programStageSection.getProgramStageDataElements().isEmpty
+                                    ()) {
+                                for (int i = 0; i
+                                        < programStageSection.getProgramStageDataElements().size();
+                                        i++) {
+                                    ProgramStageDataElement programStageDataElement =
+                                            programStageSection.getProgramStageDataElements().get(
+                                                    i);
+                                    programStageDataElement.setSortOrderWithinProgramStageSection(
+                                            i);
                                 }
                             }
 
-                            if (programStage.getProgramStageDataElements() != null && !programStage.getProgramStageDataElements().isEmpty()) {
-                                for (ProgramStageDataElement programStageDataElement : programStage.getProgramStageDataElements()) {
-                                    if (programStageDataElement.getDataElement() != null && programStageDataElement.getDataElement().getOptionSet() != null) {
-                                        OptionSet optionSet = programStageDataElement.getDataElement().getOptionSet();
+                            if (programStage.getProgramStageDataElements() != null
+                                    && !programStage.getProgramStageDataElements().isEmpty()) {
+                                for (ProgramStageDataElement programStageDataElement :
+                                        programStage.getProgramStageDataElements()) {
+                                    if (programStageDataElement.getDataElement() != null &&
+                                            programStageDataElement.getDataElement().getOptionSet()
+                                                    != null) {
+                                        OptionSet optionSet =
+                                                programStageDataElement.getDataElement()
+                                                        .getOptionSet();
 
                                         if (optionSet.getOptions() != null) {
-                                            for (int i = 0; i < optionSet.getOptions().size(); i++) {
+                                            for (int i = 0; i < optionSet.getOptions().size();
+                                                    i++) {
                                                 Option option = optionSet.getOptions().get(i);
                                                 option.setSortOrder(i);
                                             }
@@ -153,5 +199,32 @@ public class ProgramApiClientImpl implements ProgramApiClient {
             }
         }
         return programs;
+    }
+
+    private void AssignProgramStageDataElementToSections(ProgramStageSection programStageSection,
+            List<ProgramStageDataElement> programStageDataElements) {
+        Map<String, ProgramStageDataElement> stageDataElementMap = new HashMap<>();
+
+        if (programStageDataElements != null) {
+            for (ProgramStageDataElement programStageDataElement : programStageDataElements) {
+                if (programStageDataElement.getDataElement() != null) {
+                    stageDataElementMap.put(programStageDataElement.getDataElement().getUId(),
+                            programStageDataElement);
+                }
+            }
+        }
+
+        List<ProgramStageDataElement> programStageDataElementsToAddInSection = new ArrayList<>();
+
+        if (programStageSection.getDataElements() != null) {
+            for (DataElement dataElement : programStageSection.getDataElements()) {
+                ProgramStageDataElement programStageDataElement =
+                        stageDataElementMap.get(dataElement.getUId());
+
+                programStageDataElementsToAddInSection.add(programStageDataElement);
+            }
+        }
+
+        programStageSection.setProgramStageDataElements(programStageDataElementsToAddInSection);
     }
 }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramStageSectionApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramStageSectionApiClientImpl.java
@@ -76,7 +76,7 @@ public class ProgramStageSectionApiClientImpl implements ProgramStageSectionApiC
 
         @Override
         public String getBasicProperties() {
-            return "id,programStageDataElements[id]";
+            return "id,dataElements[id]";
         }
 
         @Override

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramStageDataElementControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramStageDataElementControllerImpl.java
@@ -41,11 +41,13 @@ import org.hisp.dhis.client.sdk.core.common.preferences.ResourceType;
 import org.hisp.dhis.client.sdk.core.common.utils.ModelUtils;
 import org.hisp.dhis.client.sdk.core.dataelement.DataElementController;
 import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
+import org.hisp.dhis.client.sdk.models.dataelement.DataElement;
 import org.hisp.dhis.client.sdk.models.program.ProgramStageDataElement;
 import org.hisp.dhis.client.sdk.models.program.ProgramStageSection;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -174,21 +176,31 @@ public class ProgramStageDataElementControllerImpl
             return updatedElements;
         }
 
-        Map<String, ProgramStageDataElement> stageDataElementMap =
-                ModelUtils.toMap(updatedElements);
+        Map<String, ProgramStageDataElement> stageDataElementMap = new HashMap<>();
+
+        if (updatedElements != null) {
+            for (ProgramStageDataElement programStageDataElement : updatedElements) {
+                if (programStageDataElement.getDataElement() != null) {
+                    stageDataElementMap.put(programStageDataElement.getDataElement().getUId(),
+                            programStageDataElement);
+                }
+            }
+        }
+
         for (ProgramStageSection stageSection : sections) {
-            if (stageSection.getProgramStageDataElements() == null ||
-                    stageSection.getProgramStageDataElements().isEmpty()) {
+            if (stageSection.getDataElements() == null ||
+                    stageSection.getDataElements().isEmpty()) {
                 continue;
             }
 
-            for (ProgramStageDataElement element : stageSection.getProgramStageDataElements()) {
+            for (DataElement dataElement : stageSection.getDataElements()) {
                 ProgramStageDataElement updatedDataElement =
-                        stageDataElementMap.get(element.getUId());
+                        stageDataElementMap.get(dataElement.getUId());
                 updatedDataElement.setProgramStageSection(stageSection);
-                updatedDataElement.setSortOrderWithinProgramStageSection(element.getSortOrderWithinProgramStageSection());
             }
         }
+
+
 
         return updatedElements;
     }

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/program/ProgramStageSection.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/program/ProgramStageSection.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.hisp.dhis.client.sdk.models.common.base.BaseIdentifiableObject;
+import org.hisp.dhis.client.sdk.models.dataelement.DataElement;
 
 import java.util.Comparator;
 import java.util.List;
@@ -49,6 +50,9 @@ public final class ProgramStageSection extends BaseIdentifiableObject {
 
     @JsonProperty("programStageDataElements")
     private List<ProgramStageDataElement> programStageDataElements;
+
+    @JsonProperty("dataElements")
+    private List<DataElement> dataElements;
 
     @JsonProperty("programIndicators")
     private List<ProgramIndicator> programIndicators;
@@ -76,6 +80,15 @@ public final class ProgramStageSection extends BaseIdentifiableObject {
     public void setProgramStageDataElements(List<ProgramStageDataElement>
                                                     programStageDataElements) {
         this.programStageDataElements = programStageDataElements;
+    }
+
+    public List<DataElement> getDataElements() {
+        return dataElements;
+    }
+
+    public void setDataElements(List<DataElement>
+            dataElements) {
+        this.dataElements = dataElements;
     }
 
     public List<ProgramIndicator> getProgramIndicators() {


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2105
* **Related pull-requests:** 

### :tophat: What is the goal?

The goal is to upgrade to 2.30 version the EyeSeeTea Dhis SDK.

This PR contains the upgrade to 2.30 the /program and  /programStageSections endpoints in relation to ProgramStageDataElement children under ProgramStageSections

### :memo: How is it being implemented?

In 2.30 the API does not return anymore programStagedataElements as children of ProgramStageSections.
The affected endpoints are  /program and  /programStageSections
Now the DataElements are returned as children of programStageSections.

**Program endpoint**

In the 2.25 API response, every programStageSection has a programStageDataElements and SDK work with this dependency. In 2.30 every programStageSection has a DataElements then when the response arrives I assign in memory the required relation. When program is downloaded I assign programStagedataElements to programStageSection reading programStagedataElements children of ProgramStage comparing with DataElements in programStageSections. This logic is realized in **AssignProgramStageDataElementToSections** method.

**ProgramStageSection enpoint**
In the 2.25 API response, every programStageSection has a programStageDataElements, this relation is used here to assign the programStageSection to every programStagedataElements in ProgramStageDataElementControlerImp where receive as arguments downloaded ProgramStageSections and ProgramStageDataElements. In 2.30 every programStageSection has a DataElements then in inverseSectionToElementRelationships in instead of search ProgramStageDataElements by ProgramStageDataElement uid I change to search by dataelement uid an then set programStageSection.

### :boom: How can it be tested?

- [x] **Use case 1:** Realize login against https://latest.psi-mis.org (2.30) then login should work and navigate to InProgress activity, the complete pull should work realizing all request and all conversions. Now the problem is that the events have not been downloaded but this error will be fixed in the next issue.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

