### PR TITLE
Feature upgrade to 2 30 fix post event error 500

### DIFF
--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/api/D2.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/api/D2.java
@@ -288,6 +288,7 @@ public class D2 {
                 preferencesModule.getUserPreferences(),
                 servicesModule.getUserAccountService(),
                 controllersModule.getUserAccountController(),
+                controllersModule.getCategoryOptionController(),
                 userAccountInteractor,
                 userProgramInteractor,
                 userOrganisationUnitInteractor,

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/categoryoption/CategoryOptionApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/categoryoption/CategoryOptionApiClientImpl.java
@@ -4,7 +4,11 @@ package org.hisp.dhis.client.sdk.android.categoryoption;
 import static android.R.attr.id;
 import static android.R.attr.level;
 
+import static org.hisp.dhis.client.sdk.android.api.network.NetworkUtils.call;
 import static org.hisp.dhis.client.sdk.android.api.network.NetworkUtils.getCollection;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.hisp.dhis.client.sdk.android.api.network.ApiResource;
 import org.hisp.dhis.client.sdk.android.attributes.AttributeApiClientRetrofit;
@@ -16,6 +20,8 @@ import org.hisp.dhis.client.sdk.models.attribute.Attribute;
 import org.hisp.dhis.client.sdk.models.category.CategoryOption;
 import org.joda.time.DateTime;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -66,5 +72,36 @@ public class CategoryOptionApiClientImpl implements CategoryOptionApiClient {
         List<CategoryOption> categoryOptions = getCollection(apiResource, fields, null, null);
 
         return categoryOptions;
+    }
+
+    @Override
+    public CategoryOption getDefaultCategoryOption()
+            throws ApiException {
+
+        Map<String, String> queryMap = new HashMap<>();
+        List<String> filters = new ArrayList<>();
+
+        /* disable paging */
+        queryMap.put("paging", "false");
+
+        queryMap.put("fields","id,shortName,displayName,created,lastUpdated,code");
+
+        List<CategoryOption> categoryOptions = new ArrayList<>();
+
+        categoryOptions.addAll(unwrap(call(categoryOptionApiClientRetrofit.getDefaultCategoryOption(queryMap)), "categoryOptions"));
+
+        if (categoryOptions.size() == 1)
+            return categoryOptions.get(0);
+        else
+            return null;
+    }
+
+    @NonNull
+    public static <T> List<T> unwrap(@Nullable Map<String, List<T>> response, @NonNull String key) {
+        if (response != null && response.containsKey(key) && response.get(key) != null) {
+            return response.get(key);
+        } else {
+            return new ArrayList<>();
+        }
     }
 }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/categoryoption/CategoryOptionApiClientRetrofit.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/categoryoption/CategoryOptionApiClientRetrofit.java
@@ -15,4 +15,8 @@ public interface CategoryOptionApiClientRetrofit {
     @GET("categoryOptions")
     Call<Map<String, List<CategoryOption>>> getCategoryOptions(
             @QueryMap Map<String, String> queryMap);
+
+    @GET("categoryOptions?&filter=displayName:eq:default")
+    Call<Map<String, List<CategoryOption>>> getDefaultCategoryOption(
+            @QueryMap Map<String, String> queryMap);
 }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/categoryoption/CategoryOptionStoreImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/categoryoption/CategoryOptionStoreImpl.java
@@ -1,7 +1,10 @@
 
 package org.hisp.dhis.client.sdk.android.categoryoption;
 
+import com.raizlabs.android.dbflow.sql.language.Select;
+
 import org.hisp.dhis.client.sdk.android.api.persistence.flow.CategoryOptionFlow;
+import org.hisp.dhis.client.sdk.android.api.persistence.flow.CategoryOptionFlow_Table;
 import org.hisp.dhis.client.sdk.android.common.AbsStore;
 import org.hisp.dhis.client.sdk.core.categoryoption.CategoryOptionStore;
 import org.hisp.dhis.client.sdk.core.common.persistence.TransactionManager;
@@ -15,5 +18,15 @@ public class CategoryOptionStoreImpl extends AbsStore<CategoryOption, CategoryOp
         super(CategoryOptionFlow.MAPPER);
 
         this.transactionManager = transactionManager;
+    }
+
+    @Override
+    public CategoryOption queryDefault() {
+        CategoryOptionFlow categoryOptionFlow = new Select()
+                .from(CategoryOptionFlow.class)
+                .where(CategoryOptionFlow_Table.displayName.eq("default"))
+                .querySingle();
+
+        return mapper.mapToModel(categoryOptionFlow);
     }
 }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/common/AbsStore.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/common/AbsStore.java
@@ -44,7 +44,7 @@ import static org.hisp.dhis.client.sdk.utils.Preconditions.isNull;
 
 public abstract class AbsStore<ModelType extends Model,
         DatabaseEntityType extends com.raizlabs.android.dbflow.structure.Model & Model> implements Store<ModelType> {
-    private final Mapper<ModelType, DatabaseEntityType> mapper;
+    protected final Mapper<ModelType, DatabaseEntityType> mapper;
 
     public AbsStore(Mapper<ModelType, DatabaseEntityType> mapper) {
         this.mapper = isNull(mapper, "mapper object must not be null");

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramApiClientImpl.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.client.sdk.android.program;
 import org.hisp.dhis.client.sdk.android.api.network.ApiResource;
 import org.hisp.dhis.client.sdk.core.common.Fields;
 import org.hisp.dhis.client.sdk.core.common.network.ApiException;
+import org.hisp.dhis.client.sdk.core.dataelement.DataElementApiClient;
 import org.hisp.dhis.client.sdk.core.program.ProgramApiClient;
 import org.hisp.dhis.client.sdk.models.optionset.Option;
 import org.hisp.dhis.client.sdk.models.optionset.OptionSet;
@@ -38,8 +39,11 @@ import org.hisp.dhis.client.sdk.models.program.Program;
 import org.hisp.dhis.client.sdk.models.program.ProgramStage;
 import org.hisp.dhis.client.sdk.models.program.ProgramStageDataElement;
 import org.hisp.dhis.client.sdk.models.program.ProgramStageSection;
+import org.hisp.dhis.client.sdk.models.dataelement.DataElement;
 import org.joda.time.DateTime;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,31 +88,52 @@ public class ProgramApiClientImpl implements ProgramApiClient {
             @Override
             public String getDescendantProperties() {
                 return IDENTIFIABLE_PROPERTIES + "," + ATTRIBUTEVALUES_PROPERTIES
-                        + ",version,programType,organisationUnits[id],trackedEntity[" + IDENTIFIABLE_PROPERTIES + "]," +
-                        "programTrackedEntityAttributes[" + IDENTIFIABLE_PROPERTIES + ",mandatory," + // start programTrackedEntityAttributes
-                        "displayShortName,externalAccess,valueType,allowFutureDate,displayInList,program[id]," +
-                        "trackedEntityAttribute[" + IDENTIFIABLE_PROPERTIES + ",unique,programScope," + // start trackedEntityAttribute of parent programTrackedEntityAttributes
-                        "orgunitScope,displayInListNoProgram,displayOnVisitSchedule,externalAccess," +
-                        "valueType,confidential,inherit,sortOrderVisitSchedule,dimension,sortOrderInListNoProgram," +
-                        "optionSet[" + IDENTIFIABLE_PROPERTIES + ",version,options[" + IDENTIFIABLE_PROPERTIES + ",code]]]]" + //end programTrackedEntityAttributes
+                        + ",version,programType,organisationUnits[id],trackedEntity["
+                        + IDENTIFIABLE_PROPERTIES + "]," +
+                        "programTrackedEntityAttributes[" + IDENTIFIABLE_PROPERTIES + ",mandatory,"
+                        + // start programTrackedEntityAttributes
+                        "displayShortName,externalAccess,valueType,allowFutureDate,displayInList,"
+                        + "program[id],"
+                        +
+                        "trackedEntityAttribute[" + IDENTIFIABLE_PROPERTIES
+                        + ",unique,programScope," +
+                        // start trackedEntityAttribute of parent programTrackedEntityAttributes
+                        "orgunitScope,displayInListNoProgram,displayOnVisitSchedule,externalAccess,"
+                        +
+                        "valueType,confidential,inherit,sortOrderVisitSchedule,dimension,"
+                        + "sortOrderInListNoProgram,"
+                        +
+                        "optionSet[" + IDENTIFIABLE_PROPERTIES + ",version,options["
+                        + IDENTIFIABLE_PROPERTIES + ",code]]]]" +
+                        //end programTrackedEntityAttributes
                         ",displayFrontPageList,useFirstStageDuringRegistration," +
-                        "selectEnrollmentDatesInFuture,incidentDateLabel,selectIncidentDatesInFuture," +
-                        "onlyEnrollOnce,enrollmentDateLabel,ignoreOverdueEvents,displayIncidentDate," +
+                        "selectEnrollmentDatesInFuture,incidentDateLabel,"
+                        + "selectIncidentDatesInFuture,"
+                        +
+                        "onlyEnrollOnce,enrollmentDateLabel,ignoreOverdueEvents,"
+                        + "displayIncidentDate,"
+                        +
                         "withoutRegistration,registration,relationshipFromA," +
-                        "programStages[" + IDENTIFIABLE_PROPERTIES + ",dataEntryType," + // start programStages
+                        "programStages[" + IDENTIFIABLE_PROPERTIES + ",dataEntryType," +
+                        // start programStages
                         "blockEntryForm,reportDateDescription,executionDateLabel," +
                         "displayGenerateEventBox,description,externalAccess,openAfterEnrollment," +
                         "captureCoordinates,defaultTemplateMessage,remindCompleted," +
                         "validCompleteOnly,sortOrder,generatedByEnrollmentDate,preGenerateUID," +
                         "autoGenerateEvent,allowGenerateNextVisit,repeatable,minDaysFromStart," +
-                        "program[id],programStageSections[" + IDENTIFIABLE_PROPERTIES + ",sortOrder," + // start programStageSections of parent programStages
-                        "programStage[id],programStageDataElements[id]" + "]," +
-                        "programStageDataElements[" + IDENTIFIABLE_PROPERTIES + ",programStage[id]," + // start programStageDataElements of parent programStageSections
+                        "program[id],programStageSections[" + IDENTIFIABLE_PROPERTIES
+                        + ",sortOrder," + // start programStageSections of parent programStages
+                        "programStage[id],dataElements[id]" + "]," +
+                        "programStageDataElements[" + IDENTIFIABLE_PROPERTIES + ",programStage[id],"
+                        + // start programStageDataElements of parent programStageSections
                         "allowFutureDate,sortOrder,displayInReports,allowProvidedElsewhere," +
-                        "compulsory,dataElement[code,description," +ATTRIBUTEVALUES_PROPERTIES + "," +
-                        IDENTIFIABLE_PROPERTIES + "shortName,valueType," + // start dataElement of parent programStageDataElements
+                        "compulsory,dataElement[code,description," + ATTRIBUTEVALUES_PROPERTIES
+                        + "," +
+                        IDENTIFIABLE_PROPERTIES + "shortName,valueType," +
+                        // start dataElement of parent programStageDataElements
                         "zeroIsSignificant,aggregationOperator,formName,numberType,domainType," +
-                        "dimension,displayFormName,optionSet[" + IDENTIFIABLE_PROPERTIES + // start optionSet of parent dataElement
+                        "dimension,displayFormName,optionSet[" + IDENTIFIABLE_PROPERTIES +
+                        // start optionSet of parent dataElement
                         ",version,options[" + IDENTIFIABLE_PROPERTIES + ",code]]]]]"; // end
             }
 
@@ -121,25 +146,46 @@ public class ProgramApiClientImpl implements ProgramApiClient {
 
         List<Program> programs = getCollection(apiResource, fields, lastUpdated, uids);
 
+
         for (Program program : programs) {
             if (program.getProgramStages() != null && !program.getProgramStages().isEmpty()) {
                 for (ProgramStage programStage : program.getProgramStages()) {
-                    if (programStage.getProgramStageSections() != null && !programStage.getProgramStageSections().isEmpty()) {
-                        for (ProgramStageSection programStageSection : programStage.getProgramStageSections()) {
-                            if (programStageSection.getProgramStageDataElements() != null && !programStageSection.getProgramStageDataElements().isEmpty()) {
-                                for (int i = 0; i < programStageSection.getProgramStageDataElements().size(); i++) {
-                                    ProgramStageDataElement programStageDataElement = programStageSection.getProgramStageDataElements().get(i);
-                                    programStageDataElement.setSortOrderWithinProgramStageSection(i);
+                    if (programStage.getProgramStageSections() != null
+                            && !programStage.getProgramStageSections().isEmpty()) {
+                        for (ProgramStageSection programStageSection : programStage
+                                .getProgramStageSections()) {
+
+                            AssignProgramStageDataElementToSections(programStageSection,
+                                    programStage.getProgramStageDataElements());
+
+                            if (programStageSection.getProgramStageDataElements() != null
+                                    && !programStageSection.getProgramStageDataElements().isEmpty
+                                    ()) {
+                                for (int i = 0; i
+                                        < programStageSection.getProgramStageDataElements().size();
+                                        i++) {
+                                    ProgramStageDataElement programStageDataElement =
+                                            programStageSection.getProgramStageDataElements().get(
+                                                    i);
+                                    programStageDataElement.setSortOrderWithinProgramStageSection(
+                                            i);
                                 }
                             }
 
-                            if (programStage.getProgramStageDataElements() != null && !programStage.getProgramStageDataElements().isEmpty()) {
-                                for (ProgramStageDataElement programStageDataElement : programStage.getProgramStageDataElements()) {
-                                    if (programStageDataElement.getDataElement() != null && programStageDataElement.getDataElement().getOptionSet() != null) {
-                                        OptionSet optionSet = programStageDataElement.getDataElement().getOptionSet();
+                            if (programStage.getProgramStageDataElements() != null
+                                    && !programStage.getProgramStageDataElements().isEmpty()) {
+                                for (ProgramStageDataElement programStageDataElement :
+                                        programStage.getProgramStageDataElements()) {
+                                    if (programStageDataElement.getDataElement() != null &&
+                                            programStageDataElement.getDataElement().getOptionSet()
+                                                    != null) {
+                                        OptionSet optionSet =
+                                                programStageDataElement.getDataElement()
+                                                        .getOptionSet();
 
                                         if (optionSet.getOptions() != null) {
-                                            for (int i = 0; i < optionSet.getOptions().size(); i++) {
+                                            for (int i = 0; i < optionSet.getOptions().size();
+                                                    i++) {
                                                 Option option = optionSet.getOptions().get(i);
                                                 option.setSortOrder(i);
                                             }
@@ -153,5 +199,32 @@ public class ProgramApiClientImpl implements ProgramApiClient {
             }
         }
         return programs;
+    }
+
+    private void AssignProgramStageDataElementToSections(ProgramStageSection programStageSection,
+            List<ProgramStageDataElement> programStageDataElements) {
+        Map<String, ProgramStageDataElement> stageDataElementMap = new HashMap<>();
+
+        if (programStageDataElements != null) {
+            for (ProgramStageDataElement programStageDataElement : programStageDataElements) {
+                if (programStageDataElement.getDataElement() != null) {
+                    stageDataElementMap.put(programStageDataElement.getDataElement().getUId(),
+                            programStageDataElement);
+                }
+            }
+        }
+
+        List<ProgramStageDataElement> programStageDataElementsToAddInSection = new ArrayList<>();
+
+        if (programStageSection.getDataElements() != null) {
+            for (DataElement dataElement : programStageSection.getDataElements()) {
+                ProgramStageDataElement programStageDataElement =
+                        stageDataElementMap.get(dataElement.getUId());
+
+                programStageDataElementsToAddInSection.add(programStageDataElement);
+            }
+        }
+
+        programStageSection.setProgramStageDataElements(programStageDataElementsToAddInSection);
     }
 }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramStageDataElementApiClientRetrofit.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramStageDataElementApiClientRetrofit.java
@@ -29,7 +29,7 @@
 package org.hisp.dhis.client.sdk.android.program;
 
 
-import org.hisp.dhis.client.sdk.models.program.ProgramStageDataElement;
+import org.hisp.dhis.client.sdk.models.program.Program;
 
 import java.util.List;
 import java.util.Map;
@@ -40,7 +40,7 @@ import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 
 public interface ProgramStageDataElementApiClientRetrofit {
-    @GET("programStageDataElements")
-    Call<Map<String, List<ProgramStageDataElement>>> getProgramStageDataElements(
+    @GET("programs")
+    Call<Map<String, List<Program>>> getProgramStageDataElements(
             @QueryMap Map<String, String> queryMap, @Query("filter") List<String> filters);
 }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramStageSectionApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/program/ProgramStageSectionApiClientImpl.java
@@ -76,7 +76,7 @@ public class ProgramStageSectionApiClientImpl implements ProgramStageSectionApiC
 
         @Override
         public String getBasicProperties() {
-            return "id,programStageDataElements[id]";
+            return "id,dataElements[id]";
         }
 
         @Override

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/CurrentUserInteractorImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/CurrentUserInteractorImpl.java
@@ -32,6 +32,8 @@ package org.hisp.dhis.client.sdk.android.user;
 import org.hisp.dhis.client.sdk.android.api.utils.DefaultOnSubscribe;
 import org.hisp.dhis.client.sdk.android.organisationunit.UserOrganisationUnitInteractor;
 import org.hisp.dhis.client.sdk.android.program.UserProgramInteractor;
+import org.hisp.dhis.client.sdk.core.categoryoption.CategoryOptionController;
+import org.hisp.dhis.client.sdk.core.categoryoption.CategoryOptionControllerImpl;
 import org.hisp.dhis.client.sdk.core.common.network.UserCredentials;
 import org.hisp.dhis.client.sdk.core.common.persistence.PersistenceModule;
 import org.hisp.dhis.client.sdk.core.common.preferences.PreferencesModule;
@@ -51,6 +53,7 @@ public class CurrentUserInteractorImpl implements CurrentUserInteractor {
 
     // controllers
     private final UserAccountController userAccountController;
+    private final CategoryOptionController categoryOptionController;
 
     // interactors
     private final UserAccountInteractor userAccountInteractor;
@@ -64,6 +67,7 @@ public class CurrentUserInteractorImpl implements CurrentUserInteractor {
     public CurrentUserInteractorImpl(UserPreferences userPreferences,
                                      UserAccountService userAccountService,
                                      UserAccountController userAccountController,
+                                     CategoryOptionController categoryOptionController,
                                      UserAccountInteractor userAccountInteractor,
                                      UserProgramInteractor userProgramInteractor,
                                      UserOrganisationUnitInteractor organisationUnitInteractor,
@@ -72,6 +76,7 @@ public class CurrentUserInteractorImpl implements CurrentUserInteractor {
         this.userPreferences = userPreferences;
         this.userAccountService = userAccountService;
         this.userAccountController = userAccountController;
+        this.categoryOptionController = categoryOptionController;
         this.userAccountInteractor = userAccountInteractor;
         this.userProgramInteractor = userProgramInteractor;
         this.organisationUnitInteractor = organisationUnitInteractor;
@@ -92,9 +97,17 @@ public class CurrentUserInteractorImpl implements CurrentUserInteractor {
                 userPreferences.save(userCredentials);
 
                 userAccountController.pull();
+
+                pullDefaultCategoryOption();
+
                 return userAccountService.get();
             }
         });
+    }
+
+    private void pullDefaultCategoryOption() {
+        //Default category option is necessary to push events
+        categoryOptionController.pullDefault();
     }
 
     @Override

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/UserAccountApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/UserAccountApiClientImpl.java
@@ -28,13 +28,13 @@
 
 package org.hisp.dhis.client.sdk.android.user;
 
+import static org.hisp.dhis.client.sdk.android.api.network.NetworkUtils.call;
+
 import org.hisp.dhis.client.sdk.core.user.UserApiClient;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.hisp.dhis.client.sdk.android.api.network.NetworkUtils.call;
 
 public class UserAccountApiClientImpl implements UserApiClient {
     private final UserApiClientRetrofit apiClient;
@@ -44,14 +44,14 @@ public class UserAccountApiClientImpl implements UserApiClient {
     }
 
     @Override
-    public UserAccount getUserAccount() {
+    public UserAccount getUserAccount(int apiVersion) {
         Map<String, String> QUERY_PARAMS = new HashMap<>();
         QUERY_PARAMS.put("fields", "id,created,lastUpdated,name,displayName," +
                 "firstName,surname,gender,birthday,introduction," +
                 "education,employer,interests,jobTitle,languages,email,phoneNumber," +
-                "organisationUnits[id],userCredentials[userRoles[dataSets[id],programs[id,programType]]]");
+                "organisationUnits[id,programs[id,programType]],userCredentials[userRoles], programs, dataSets");
 
-        return call(apiClient.getCurrentUserAccount(QUERY_PARAMS));
+        return call(apiClient.getCurrentUserAccount(apiVersion, QUERY_PARAMS));
     }
 
     @Override

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/UserApiClientRetrofit.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/user/UserApiClientRetrofit.java
@@ -33,11 +33,11 @@ import org.hisp.dhis.client.sdk.models.user.UserAccount;
 
 import java.util.Map;
 
-import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
 import retrofit2.http.QueryMap;
 
 public interface UserApiClientRetrofit {
@@ -46,8 +46,9 @@ public interface UserApiClientRetrofit {
     // Methods for getting user information
     /////////////////////////////////////////////////////////////////////////
 
-    @GET("me/")
-    Call<UserAccount> getCurrentUserAccount(@QueryMap Map<String, String> queryParams);
+    @GET("{apiVersion}/me")
+    Call<UserAccount> getCurrentUserAccount(@Path("apiVersion") int apiVersion,
+            @QueryMap Map<String, String> queryParams);
 
     @POST("me/profile")
     Call<Void> postCurrentUserAccount(@Body UserAccount userAccount);

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/categoryoption/CategoryOptionApiClient.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/categoryoption/CategoryOptionApiClient.java
@@ -13,4 +13,6 @@ import java.util.Set;
 public interface CategoryOptionApiClient {
     List<CategoryOption> getCategoryOptions(
             Fields fields, DateTime lastUpdated, Set<String> uids) throws ApiException;
+
+    CategoryOption getDefaultCategoryOption() throws ApiException;
 }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/categoryoption/CategoryOptionController.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/categoryoption/CategoryOptionController.java
@@ -5,4 +5,5 @@ import org.hisp.dhis.client.sdk.core.common.network.ApiException;
 
 public interface CategoryOptionController {
     void pull() throws ApiException;
+    void pullDefault()throws ApiException;
 }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/categoryoption/CategoryOptionControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/categoryoption/CategoryOptionControllerImpl.java
@@ -55,4 +55,20 @@ public class CategoryOptionControllerImpl implements CategoryOptionController {
 
         lastUpdatedPreferences.save(ResourceType.CATEGORYOPTIONS, DateType.SERVER, serverTime);
     }
+
+    @Override
+    public void pullDefault() throws ApiException {
+
+        DateTime serverTime = systemInfoController.getSystemInfo().getServerDate();
+        CategoryOption defaultCategoryOption = categoryOptionApiClient
+                .getDefaultCategoryOption();
+
+        List<DbOperation> dbOperations = new ArrayList<>();
+        dbOperations.add(DbOperationImpl.with(categoryOptionStore)
+                .save(defaultCategoryOption));
+
+        transactionManager.transact(dbOperations);
+
+        lastUpdatedPreferences.save(ResourceType.CATEGORYOPTIONS, DateType.SERVER, serverTime);
+    }
 }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/categoryoption/CategoryOptionStore.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/categoryoption/CategoryOptionStore.java
@@ -5,4 +5,5 @@ import org.hisp.dhis.client.sdk.core.common.persistence.Store;
 import org.hisp.dhis.client.sdk.models.category.CategoryOption;
 
 public interface CategoryOptionStore extends Store<CategoryOption> {
+    CategoryOption queryDefault();
 }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/common/controllers/ControllersModuleImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/common/controllers/ControllersModuleImpl.java
@@ -282,6 +282,7 @@ public class ControllersModuleImpl implements ControllersModule {
                 preferencesModule.getLastUpdatedPreferences(),
                 persistenceModule.getEventStore(),
                 persistenceModule.getStateStore(),
+                persistenceModule.getCategoryOptionStore(),
                 persistenceModule.getTransactionManager(), logger);
 
         enrollmentController = new EnrollmentControllerImpl(networkModule.getEnrollmentApiClient(),

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/common/controllers/ControllersModuleImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/common/controllers/ControllersModuleImpl.java
@@ -183,7 +183,7 @@ public class ControllersModuleImpl implements ControllersModule {
                 preferencesModule.getLastUpdatedPreferences(),
                 persistenceModule.getTransactionManager());
 
-        assignedProgramsController = new AssignedProgramsControllerImpl(
+        assignedProgramsController = new AssignedProgramsControllerImpl(systemInfoController,
                 programControllerImpl, networkModule.getUserApiClient());
 
         organisationUnitController = new OrganisationUnitControllerImpl(
@@ -202,9 +202,10 @@ public class ControllersModuleImpl implements ControllersModule {
                 persistenceModule.getTransactionManager());
 
         assignedOrganisationUnitsController = new AssignedOrganisationUnitControllerImpl(
-                organisationUnitController, networkModule.getUserApiClient());
+                systemInfoController, organisationUnitController, networkModule.getUserApiClient());
 
         userAccountController = new UserAccountControllerImpl(
+                systemInfoController,
                 networkModule.getUserApiClient(),
                 persistenceModule.getUserAccountStore(),
                 persistenceModule.getAttributeValueStore(),

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/organisationunit/OrganisationUnitControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/organisationunit/OrganisationUnitControllerImpl.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.client.sdk.core.common.utils.ModelUtils;
 import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.core.user.UserApiClient;
 import org.hisp.dhis.client.sdk.models.attribute.AttributeValue;
+import org.hisp.dhis.client.sdk.models.common.SystemInfo;
 import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnit;
 import org.joda.time.DateTime;
 
@@ -84,7 +85,8 @@ public class OrganisationUnitControllerImpl extends AbsSyncStrategyController<Or
 
     @Override
     protected void synchronize(SyncStrategy strategy, Set<String> uids) {
-        DateTime serverTime = systemInfoController.getSystemInfo().getServerDate();
+        SystemInfo systemInfo = systemInfoController.getSystemInfo();
+        DateTime serverTime = systemInfo.getServerDate();
         DateTime lastUpdated = lastUpdatedPreferences.get(
                 ResourceType.ORGANISATION_UNITS, DateType.SERVER);
 
@@ -122,7 +124,8 @@ public class OrganisationUnitControllerImpl extends AbsSyncStrategyController<Or
 
         // we need to mark assigned organisation units as "assigned" before storing them
         Map<String, OrganisationUnit> assignedOrganisationUnits = ModelUtils
-                .toMap(userApiClient.getUserAccount().getOrganisationUnits());
+                .toMap(userApiClient.getUserAccount(systemInfo.getApiVersion())
+                        .getOrganisationUnits());
 
         for (OrganisationUnit updatedOrganisationUnit : updatedOrganisationUnits) {
             OrganisationUnit assignedOrganisationUnit = assignedOrganisationUnits
@@ -156,7 +159,8 @@ public class OrganisationUnitControllerImpl extends AbsSyncStrategyController<Or
     @Override
     public List<OrganisationUnit> pullAllDescendants(SyncStrategy strategy, String uid)
             throws ApiException {
-        DateTime serverTime = systemInfoController.getSystemInfo().getServerDate();
+        SystemInfo systemInfo = systemInfoController.getSystemInfo();
+        DateTime serverTime = systemInfo.getServerDate();
         DateTime lastUpdated = lastUpdatedPreferences.get(
                 ResourceType.ORGANISATION_UNITS, DateType.SERVER);
 
@@ -183,7 +187,8 @@ public class OrganisationUnitControllerImpl extends AbsSyncStrategyController<Or
 
         // we need to mark assigned organisation units as "assigned" before storing them
         Map<String, OrganisationUnit> assignedOrganisationUnits = ModelUtils
-                .toMap(userApiClient.getUserAccount().getOrganisationUnits());
+                .toMap(userApiClient.getUserAccount(systemInfo.getApiVersion())
+                        .getOrganisationUnits());
 
         for (OrganisationUnit updatedOrganisationUnit : updatedOrganisationUnits) {
             OrganisationUnit assignedOrganisationUnit = assignedOrganisationUnits

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramControllerImpl.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.core.trackedentity.TrackedEntityController;
 import org.hisp.dhis.client.sdk.core.user.UserApiClient;
 import org.hisp.dhis.client.sdk.models.attribute.AttributeValue;
+import org.hisp.dhis.client.sdk.models.common.SystemInfo;
 import org.hisp.dhis.client.sdk.models.dataelement.DataElement;
 import org.hisp.dhis.client.sdk.models.optionset.Option;
 import org.hisp.dhis.client.sdk.models.optionset.OptionSet;
@@ -138,7 +139,8 @@ public class ProgramControllerImpl extends
     }
 
     private void synchronizeByLastUpdated(Set<String> uids) {
-        DateTime serverTime = systemInfoController.getSystemInfo().getServerDate();
+        SystemInfo systemInfo = systemInfoController.getSystemInfo();
+        DateTime serverTime = systemInfo.getServerDate();
         DateTime lastUpdated = lastUpdatedPreferences.get(ResourceType.PROGRAMS, DateType.SERVER);
 
         List<Program> persistedPrograms = identifiableObjectStore.queryAll();
@@ -172,7 +174,7 @@ public class ProgramControllerImpl extends
         // we need to mark assigned programs as "assigned" before storing them
         // TODO remove this call (additional request which performs check if user is assigned)
         Map<String, Program> assignedPrograms = toMap(userApiClient
-                .getUserAccount().getPrograms());
+                .getUserAccount(systemInfo.getApiVersion()).getPrograms());
 
         for (Program updatedProgram : updatedPrograms) {
             Program assignedProgram = assignedPrograms.get(updatedProgram.getUId());
@@ -274,7 +276,7 @@ public class ProgramControllerImpl extends
 
         // we need to mark assigned programs as "assigned" before storing them
         Map<String, Program> assignedPrograms = toMap(userApiClient
-                .getUserAccount().getPrograms());
+                .getUserAccount(systemInfoController.getSystemInfo().getApiVersion()).getPrograms());
 
         for (Program updatedProgram : updatedPrograms) {
             Program assignedProgram = assignedPrograms.get(updatedProgram.getUId());

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramStageDataElementControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/program/ProgramStageDataElementControllerImpl.java
@@ -41,11 +41,13 @@ import org.hisp.dhis.client.sdk.core.common.preferences.ResourceType;
 import org.hisp.dhis.client.sdk.core.common.utils.ModelUtils;
 import org.hisp.dhis.client.sdk.core.dataelement.DataElementController;
 import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
+import org.hisp.dhis.client.sdk.models.dataelement.DataElement;
 import org.hisp.dhis.client.sdk.models.program.ProgramStageDataElement;
 import org.hisp.dhis.client.sdk.models.program.ProgramStageSection;
 import org.joda.time.DateTime;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -174,21 +176,31 @@ public class ProgramStageDataElementControllerImpl
             return updatedElements;
         }
 
-        Map<String, ProgramStageDataElement> stageDataElementMap =
-                ModelUtils.toMap(updatedElements);
+        Map<String, ProgramStageDataElement> stageDataElementMap = new HashMap<>();
+
+        if (updatedElements != null) {
+            for (ProgramStageDataElement programStageDataElement : updatedElements) {
+                if (programStageDataElement.getDataElement() != null) {
+                    stageDataElementMap.put(programStageDataElement.getDataElement().getUId(),
+                            programStageDataElement);
+                }
+            }
+        }
+
         for (ProgramStageSection stageSection : sections) {
-            if (stageSection.getProgramStageDataElements() == null ||
-                    stageSection.getProgramStageDataElements().isEmpty()) {
+            if (stageSection.getDataElements() == null ||
+                    stageSection.getDataElements().isEmpty()) {
                 continue;
             }
 
-            for (ProgramStageDataElement element : stageSection.getProgramStageDataElements()) {
+            for (DataElement dataElement : stageSection.getDataElements()) {
                 ProgramStageDataElement updatedDataElement =
-                        stageDataElementMap.get(element.getUId());
+                        stageDataElementMap.get(dataElement.getUId());
                 updatedDataElement.setProgramStageSection(stageSection);
-                updatedDataElement.setSortOrderWithinProgramStageSection(element.getSortOrderWithinProgramStageSection());
             }
         }
+
+
 
         return updatedElements;
     }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/user/AssignedOrganisationUnitControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/user/AssignedOrganisationUnitControllerImpl.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.client.sdk.core.common.controllers.SyncStrategy;
 import org.hisp.dhis.client.sdk.core.common.network.ApiException;
 import org.hisp.dhis.client.sdk.core.common.utils.ModelUtils;
 import org.hisp.dhis.client.sdk.core.organisationunit.OrganisationUnitController;
+import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnit;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
 
@@ -40,6 +41,7 @@ import java.util.Set;
 
 public class AssignedOrganisationUnitControllerImpl implements AssignedOrganisationUnitsController {
 
+    private final SystemInfoController systemInfoController;
     // Api Clients
     private final UserApiClient userApiClient;
 
@@ -47,7 +49,9 @@ public class AssignedOrganisationUnitControllerImpl implements AssignedOrganisat
     private final OrganisationUnitController organisationUnitController;
 
     public AssignedOrganisationUnitControllerImpl(
+            SystemInfoController systemInfoController,
             OrganisationUnitController organisationUnitController, UserApiClient userApiClient) {
+        this.systemInfoController = systemInfoController;
         this.userApiClient = userApiClient;
         this.organisationUnitController = organisationUnitController;
     }
@@ -59,7 +63,8 @@ public class AssignedOrganisationUnitControllerImpl implements AssignedOrganisat
 
     @Override
     public void sync(SyncStrategy strategy) throws ApiException {
-        UserAccount userAccount = userApiClient.getUserAccount();
+        UserAccount userAccount = userApiClient.getUserAccount(
+                systemInfoController.getSystemInfo().getApiVersion());
 
         /* get list of assigned organisation units */
         List<OrganisationUnit> assignedOrganisationUnits = userAccount.getOrganisationUnits();

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/user/AssignedProgramsControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/user/AssignedProgramsControllerImpl.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.client.sdk.core.common.network.ApiException;
 import org.hisp.dhis.client.sdk.core.common.utils.ModelUtils;
 import org.hisp.dhis.client.sdk.core.program.ProgramController;
 import org.hisp.dhis.client.sdk.core.program.ProgramFields;
+import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.models.program.Program;
 import org.hisp.dhis.client.sdk.models.program.ProgramType;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
@@ -48,14 +49,19 @@ import static org.hisp.dhis.client.sdk.utils.Preconditions.isNull;
  */
 public class AssignedProgramsControllerImpl implements AssignedProgramsController {
 
+    private final SystemInfoController systemInfoController;
+
     /* Program controller */
     private final ProgramController programController;
 
     /* Api clients */
     private final UserApiClient userApiClient;
 
-    public AssignedProgramsControllerImpl(ProgramController programController,
-                                          UserApiClient userApiClient) {
+    public AssignedProgramsControllerImpl(
+            SystemInfoController systemInfoController,
+            ProgramController programController,
+            UserApiClient userApiClient) {
+        this.systemInfoController = systemInfoController;
         this.userApiClient = userApiClient;
         this.programController = programController;
     }
@@ -74,7 +80,8 @@ public class AssignedProgramsControllerImpl implements AssignedProgramsControlle
             throw new IllegalArgumentException("Specify at least one ProgramType");
         }
 
-        UserAccount userAccount = userApiClient.getUserAccount();
+        UserAccount userAccount = userApiClient.getUserAccount(
+                systemInfoController.getSystemInfo().getApiVersion());
 
         /* get list of assigned programs */
         List<Program> assignedPrograms = userAccount.getPrograms();

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/user/UserAccountControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/user/UserAccountControllerImpl.java
@@ -31,22 +31,18 @@ package org.hisp.dhis.client.sdk.core.user;
 import org.hisp.dhis.client.sdk.core.attribute.AttributeValueStore;
 import org.hisp.dhis.client.sdk.core.common.StateStore;
 import org.hisp.dhis.client.sdk.core.common.network.ApiException;
-import org.hisp.dhis.client.sdk.core.common.persistence.DbOperation;
-import org.hisp.dhis.client.sdk.core.common.persistence.DbOperationImpl;
-import org.hisp.dhis.client.sdk.core.common.persistence.DbUtils;
 import org.hisp.dhis.client.sdk.core.common.persistence.TransactionManager;
-import org.hisp.dhis.client.sdk.models.attribute.AttributeValue;
+import org.hisp.dhis.client.sdk.core.systeminfo.SystemInfoController;
 import org.hisp.dhis.client.sdk.models.common.state.Action;
-import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnit;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
 import org.hisp.dhis.client.sdk.utils.Logger;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public final class UserAccountControllerImpl implements UserAccountController {
     private static final String TAG = UserAccountControllerImpl.class.getSimpleName();
 
+    private final SystemInfoController systemInfoController;
     private final UserApiClient userApiClient;
     private final UserAccountStore userAccountStore;
     private final StateStore stateStore;
@@ -55,11 +51,14 @@ public final class UserAccountControllerImpl implements UserAccountController {
     private final AttributeValueStore attributeValueStore;
     private final TransactionManager transactionManager;
 
-    public UserAccountControllerImpl(UserApiClient userApiClient,
-                                     UserAccountStore userAccountStore,
-                                     AttributeValueStore attributeValueStore,
-                                     TransactionManager transactionManager,
-                                     StateStore stateStore, Logger logger) {
+    public UserAccountControllerImpl(
+            SystemInfoController systemInfoController,
+            UserApiClient userApiClient,
+            UserAccountStore userAccountStore,
+            AttributeValueStore attributeValueStore,
+            TransactionManager transactionManager,
+            StateStore stateStore, Logger logger) {
+        this.systemInfoController = systemInfoController;
         this.userApiClient = userApiClient;
         this.userAccountStore = userAccountStore;
         this.attributeValueStore = attributeValueStore;
@@ -70,7 +69,8 @@ public final class UserAccountControllerImpl implements UserAccountController {
 
     @Override
     public void pull() throws ApiException {
-        UserAccount userAccount = userApiClient.getUserAccount();
+        UserAccount userAccount = userApiClient.getUserAccount(
+                systemInfoController.getSystemInfo().getApiVersion());
 
         // update userAccount in database
         userAccountStore.save(userAccount);

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/user/UserApiClient.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/user/UserApiClient.java
@@ -31,7 +31,7 @@ package org.hisp.dhis.client.sdk.core.user;
 import org.hisp.dhis.client.sdk.models.user.UserAccount;
 
 public interface UserApiClient {
-    UserAccount getUserAccount();
+    UserAccount getUserAccount(int apiVersion);
 
     void postUserAccount(UserAccount userAccount);
 }

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/SystemInfo.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/SystemInfo.java
@@ -33,6 +33,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.joda.time.DateTime;
 
+import java.util.regex.Pattern;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class SystemInfo {
 
@@ -56,6 +58,8 @@ public final class SystemInfo {
 
     @JsonProperty("version")
     String version;
+
+    private static final int latestSupportedAPIVersion = 30;
 
     public SystemInfo() {
         // explicit empty constructor
@@ -115,5 +119,15 @@ public final class SystemInfo {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public int getApiVersion() {
+        String[] completedVersionParts = version.split(Pattern.quote("."));
+        int serverVersion = Integer.parseInt(completedVersionParts[1]);
+
+        if (serverVersion > latestSupportedAPIVersion)
+            return latestSupportedAPIVersion;
+        else
+            return serverVersion;
     }
 }

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/SystemInfo.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/SystemInfo.java
@@ -59,7 +59,8 @@ public final class SystemInfo {
     @JsonProperty("version")
     String version;
 
-    private static final int latestSupportedAPIVersion = 30;
+    public static final int maxSupportedAPIVersion = 30;
+    public static final int minSupportedAPIVersion = 26;
 
     public SystemInfo() {
         // explicit empty constructor
@@ -122,12 +123,19 @@ public final class SystemInfo {
     }
 
     public int getApiVersion() {
-        String[] completedVersionParts = version.split(Pattern.quote("."));
-        int serverVersion = Integer.parseInt(completedVersionParts[1]);
+        if (version != null) {
+            String[] completedVersionParts = version.split(Pattern.quote("."));
+            int serverVersion = Integer.parseInt(completedVersionParts[1]);
 
-        if (serverVersion > latestSupportedAPIVersion)
-            return latestSupportedAPIVersion;
-        else
-            return serverVersion;
+            if (serverVersion < minSupportedAPIVersion)
+                throw new UnsupportedServerVersionException(serverVersion, minSupportedAPIVersion);
+
+            if (serverVersion > maxSupportedAPIVersion)
+                return maxSupportedAPIVersion;
+            else
+                return serverVersion;
+        } else {
+            return minSupportedAPIVersion;
+        }
     }
 }

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/UnsupportedServerVersionException.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/UnsupportedServerVersionException.java
@@ -1,0 +1,9 @@
+package org.hisp.dhis.client.sdk.models.common;
+
+public class UnsupportedServerVersionException extends RuntimeException {
+    public UnsupportedServerVersionException(int serverVersion, int minApiVersion) {
+        super(String.format(
+                "The server version %d is not supported. Minimum server version supported is %d",
+                serverVersion, minApiVersion));
+    }
+}

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/program/ProgramStageSection.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/program/ProgramStageSection.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.hisp.dhis.client.sdk.models.common.base.BaseIdentifiableObject;
+import org.hisp.dhis.client.sdk.models.dataelement.DataElement;
 
 import java.util.Comparator;
 import java.util.List;
@@ -49,6 +50,9 @@ public final class ProgramStageSection extends BaseIdentifiableObject {
 
     @JsonProperty("programStageDataElements")
     private List<ProgramStageDataElement> programStageDataElements;
+
+    @JsonProperty("dataElements")
+    private List<DataElement> dataElements;
 
     @JsonProperty("programIndicators")
     private List<ProgramIndicator> programIndicators;
@@ -76,6 +80,15 @@ public final class ProgramStageSection extends BaseIdentifiableObject {
     public void setProgramStageDataElements(List<ProgramStageDataElement>
                                                     programStageDataElements) {
         this.programStageDataElements = programStageDataElements;
+    }
+
+    public List<DataElement> getDataElements() {
+        return dataElements;
+    }
+
+    public void setDataElements(List<DataElement>
+            dataElements) {
+        this.dataElements = dataElements;
     }
 
     public List<ProgramIndicator> getProgramIndicators() {

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/user/UserRole.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/user/UserRole.java
@@ -31,37 +31,16 @@ package org.hisp.dhis.client.sdk.models.user;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.hisp.dhis.client.sdk.models.common.base.BaseIdentifiableObject;
 import org.hisp.dhis.client.sdk.models.dataset.DataSet;
 import org.hisp.dhis.client.sdk.models.program.Program;
 
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class UserRole {
-
-    @JsonProperty("programs")
-    List<Program> programs;
-
-    @JsonProperty("dataSets")
-    List<DataSet> dataSets;
+class UserRole extends BaseIdentifiableObject {
 
     public UserRole() {
         // explicit empty constructor
-    }
-
-    public List<Program> getPrograms() {
-        return programs;
-    }
-
-    public void setPrograms(List<Program> programs) {
-        this.programs = programs;
-    }
-
-    public List<DataSet> getDataSets() {
-        return dataSets;
-    }
-
-    public void setDataSets(List<DataSet> dataSets) {
-        this.dataSets = dataSets;
     }
 }

--- a/models/src/test/java/org/hisp/dhis/client/sdk/models/common/SystemInfoShould.java
+++ b/models/src/test/java/org/hisp/dhis/client/sdk/models/common/SystemInfoShould.java
@@ -1,0 +1,46 @@
+package org.hisp.dhis.client.sdk.models.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SystemInfoShould {
+
+    @Rule
+    public ExpectedException mExpectedException = ExpectedException.none();
+
+    @Test
+    public void return_min_api_version_if_server_version_is_empty() {
+        SystemInfo systemInfo = new SystemInfo();
+
+        assertThat(systemInfo.getApiVersion(),is(SystemInfo.minSupportedAPIVersion));
+    }
+
+    @Test
+    public void throw_unsupported_server_exception_if_server_version_is_smaller_than_min() {
+        mExpectedException.expect(UnsupportedServerVersionException.class);
+        SystemInfo systemInfo = new SystemInfo();
+        systemInfo.version = "2." + (SystemInfo.minSupportedAPIVersion - 6);;
+
+        systemInfo.getApiVersion();
+    }
+
+    @Test
+    public void return_max_api_version_if_server_version_greater_than_max() {
+        SystemInfo systemInfo = new SystemInfo();
+        systemInfo.version = "2." + (SystemInfo.maxSupportedAPIVersion + 1);
+
+        assertThat(systemInfo.getApiVersion(),is(SystemInfo.maxSupportedAPIVersion));
+    }
+
+    @Test
+    public void return_expected_api_version_if_server_version_is_between_thresholds() {
+        SystemInfo systemInfo = new SystemInfo();
+        systemInfo.version = "2." + (SystemInfo.maxSupportedAPIVersion - 1);
+
+        assertThat(systemInfo.getApiVersion(),is(SystemInfo.maxSupportedAPIVersion - 1));
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2106
* **Related pull-requests:** 

### :tophat: What is the goal?

The goal is to upgrade to 2.30 version the EyeSeeTea Dhis SDK.

This PR contains the fix for error 500 to push surveys to server.

### :memo: How is it being implemented?

In 2.30 for HNQIS the API response error 500 with next body:
{
   “httpStatus”: “Internal Server Error”,
   “httpStatusCode”: 500,
   “status”: “ERROR”,
   “message”: “failed to lazily initialize a collection of role: org.hisp.dhis.category.CategoryOptionCombo.categoryOptions, could not initialize proxy - no Session”
}

The problem is that now attributeCategoryOptions field for the event is mandatory.
To solve when the signIn method is invoked I download default CategoryOption and when push events method is invoked, I check attributeCategoryOptions for every event, if It's empty then assign default CategoryOption.

### :boom: How can it be tested?

- [ ] **Use case 1:** Realize login against https://latest.psi-mis.org (2.30) and create a new survey. Wait until push is realized and verify in server and logcat that the process has worked successfully.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

