### PR TITLE
Feature add put method to push events

### DIFF
--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventApiClientImpl.java
@@ -113,7 +113,7 @@ public class EventApiClientImpl implements EventApiClient {
         } else if (apiMessage.getStatus().equals("WARNING")) {
             status = ImportSummary.Status.WARNING;
         }
-        return new ImportSummary(status, apiMessage.getResponse().getImportCount(), event.getUId());
+        return new ImportSummary(status, apiMessage.getResponse().getImportCount(), event.getUId(), apiMessage.getResponse().getConflicts());
     }
 
     @Override

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventApiClientImpl.java
@@ -89,6 +89,16 @@ public class EventApiClientImpl implements EventApiClient {
     }
 
     @Override
+    public List<ApiMessage> putEvents(List<Event> events) throws ApiException {
+        List<ApiMessage> apiMessages = new ArrayList<>();
+        for(Event event : events){
+            apiMessages.add(call(eventApiclientRetrofit.putEvent(event.getUId(), event)));
+        }
+
+        return apiMessages;
+    }
+
+    @Override
     public ApiMessage deleteEvent(Event event) throws ApiException {
         return call(eventApiclientRetrofit.deleteEvent(event.getUId()));
     }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventApiClientImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventApiClientImpl.java
@@ -11,6 +11,7 @@ import org.hisp.dhis.client.sdk.core.common.network.ApiMessage;
 import org.hisp.dhis.client.sdk.core.common.utils.CollectionUtils;
 import org.hisp.dhis.client.sdk.core.event.EventApiClient;
 import org.hisp.dhis.client.sdk.core.event.EventFilters;
+import org.hisp.dhis.client.sdk.models.common.importsummary.ImportSummary;
 import org.hisp.dhis.client.sdk.models.event.Event;
 import org.hisp.dhis.client.sdk.models.event.EventWrapper;
 import org.joda.time.DateTime;
@@ -89,13 +90,30 @@ public class EventApiClientImpl implements EventApiClient {
     }
 
     @Override
-    public List<ApiMessage> putEvents(List<Event> events) throws ApiException {
-        List<ApiMessage> apiMessages = new ArrayList<>();
+    public List<ImportSummary> putEvents(List<Event> events) throws ApiException {
+        List<ImportSummary> importSummaries = new ArrayList<>();
         for(Event event : events){
-            apiMessages.add(call(eventApiclientRetrofit.putEvent(event.getUId(), event)));
+            ApiMessage apiMessage = call(eventApiclientRetrofit.putEvent(event.getUId(), event));
+            if(apiMessage!=null) {
+                importSummaries.add(fixEmptyImportSummary(event, apiMessage));
+            }
         }
 
-        return apiMessages;
+        return importSummaries;
+    }
+
+    private ImportSummary fixEmptyImportSummary(Event event, ApiMessage apiMessage) {
+        ImportSummary.Status status = ImportSummary.Status.ERROR;
+        if (apiMessage.getStatus().equals("OK")) {
+            status = ImportSummary.Status.OK;
+        } else if (apiMessage.getStatus().equals("SUCCESS")) {
+            status = ImportSummary.Status.SUCCESS;
+        } else if (apiMessage.getStatus().equals("ERROR")) {
+            status = ImportSummary.Status.ERROR;
+        } else if (apiMessage.getStatus().equals("WARNING")) {
+            status = ImportSummary.Status.WARNING;
+        }
+        return new ImportSummary(status, apiMessage.getResponse().getImportCount(), event.getUId());
     }
 
     @Override

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventApiClientRetrofit.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventApiClientRetrofit.java
@@ -40,6 +40,7 @@ import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.QueryMap;
 
@@ -56,4 +57,7 @@ public interface EventApiClientRetrofit {
 
     @GET("events")
     Call<EventWrapper> getEventsAndPager(@QueryMap Map<String, String> queryMap);
+
+    @PUT("events/{uid}")
+    Call<ApiMessage> putEvent(@Path("uid") String eventUId, @Body Event event);
 }

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventInteractor.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventInteractor.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnit;
 import org.hisp.dhis.client.sdk.models.program.Program;
 import org.hisp.dhis.client.sdk.models.program.ProgramStage;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,6 +74,8 @@ public interface EventInteractor {
     Observable<List<Event>> pull(final EventFilters eventFilters);
 
     Observable<Map<String,ImportSummary>> push(Set<String> uids);
+
+    Observable<Map<String,ImportSummary>> push(Set<String> uids, Action action);
 
     Observable<List<Event>> sync(Set<String> uids);
 

--- a/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventInteractorImpl.java
+++ b/core-android/src/main/java/org/hisp/dhis/client/sdk/android/event/EventInteractorImpl.java
@@ -28,6 +28,8 @@
 
 package org.hisp.dhis.client.sdk.android.event;
 
+import android.support.annotation.NonNull;
+
 import org.hisp.dhis.client.sdk.android.api.utils.DefaultOnSubscribe;
 import org.hisp.dhis.client.sdk.core.common.controllers.SyncStrategy;
 import org.hisp.dhis.client.sdk.core.event.EventController;
@@ -41,8 +43,6 @@ import org.hisp.dhis.client.sdk.models.organisationunit.OrganisationUnit;
 import org.hisp.dhis.client.sdk.models.program.Program;
 import org.hisp.dhis.client.sdk.models.program.ProgramStage;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,24 +105,12 @@ public class EventInteractorImpl implements EventInteractor {
 
     @Override
     public Observable<Map<String,ImportSummary>> push(final Set<String> uids) {
-        return Observable.create(new DefaultOnSubscribe<Map<String,ImportSummary>>() {
-            @Override
-            public Map<String,ImportSummary> call() {
-                Map<String,ImportSummary> importSumariesAndEventsMap = new HashMap<String, ImportSummary>();
-                List<ImportSummary> importSummaries = eventController.push(uids);
-                for(String event:uids){
-                    for(ImportSummary importSummary:importSummaries){
-                        if(importSummary.getReference()==null){
-                            importSumariesAndEventsMap.put(event,importSummary);
-                        }else if(importSummary.getReference().equals(event)){
-                                importSumariesAndEventsMap.put(event,importSummary);
-                                continue;
-                            }
-                    }
-                }
-                return importSumariesAndEventsMap;
-            }
-        });
+        return pushUids(uids, Action.TO_POST);
+    }
+
+    @Override
+    public Observable<Map<String,ImportSummary>> push(final Set<String> uids, Action action) {
+        return pushUids(uids, action);
     }
 
     @Override
@@ -218,6 +206,28 @@ public class EventInteractorImpl implements EventInteractor {
             @Override
             public List<Event> call() {
                 return eventService.listByActions(actionSet);
+            }
+        });
+    }
+
+    @NonNull
+    private Observable<Map<String, ImportSummary>> pushUids(final Set<String> uids, final Action action) {
+        return Observable.create(new DefaultOnSubscribe<Map<String,ImportSummary>>() {
+            @Override
+            public Map<String,ImportSummary> call() {
+                Map<String,ImportSummary> importSumariesAndEventsMap = new HashMap<String, ImportSummary>();
+                List<ImportSummary> importSummaries = eventController.push(uids, action);
+                for(String event:uids){
+                    for(ImportSummary importSummary:importSummaries){
+                        if(importSummary.getReference()==null){
+                            importSumariesAndEventsMap.put(event,importSummary);
+                        }else if(importSummary.getReference().equals(event)){
+                            importSumariesAndEventsMap.put(event,importSummary);
+                            continue;
+                        }
+                    }
+                }
+                return importSumariesAndEventsMap;
             }
         });
     }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/common/controllers/IdentifiableDataController.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/common/controllers/IdentifiableDataController.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.client.sdk.core.common.controllers;
 import org.hisp.dhis.client.sdk.core.common.network.ApiException;
 import org.hisp.dhis.client.sdk.models.common.base.IdentifiableObject;
 import org.hisp.dhis.client.sdk.models.common.importsummary.ImportSummary;
+import org.hisp.dhis.client.sdk.models.common.state.Action;
 
 import java.util.List;
 import java.util.Set;
@@ -43,4 +44,6 @@ public interface IdentifiableDataController<T extends IdentifiableObject>
     void sync(SyncStrategy strategy, Set<String> uids);
 
     List<ImportSummary> push(Set<String> uids) throws ApiException;
+
+    List<ImportSummary> push(Set<String> uids, Action action) throws ApiException;
 }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/common/network/ApiResponse.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/common/network/ApiResponse.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.client.sdk.core.common.network;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.hisp.dhis.client.sdk.models.common.importsummary.Conflict;
 import org.hisp.dhis.client.sdk.models.common.importsummary.ImportCount;
 import org.hisp.dhis.client.sdk.models.common.importsummary.ImportSummary;
 import org.hisp.dhis.client.sdk.models.common.importsummary.ImportSummary.Status;
@@ -52,6 +53,9 @@ public class ApiResponse {
     @JsonProperty("importSummaries")
     private List<ImportSummary> importSummaries;
 
+    @JsonProperty("conflicts")
+    private List<Conflict> conflicts;
+
     public ApiResponse() {
         // explicit empty constructor
     }
@@ -70,6 +74,10 @@ public class ApiResponse {
 
     public List<ImportSummary> getImportSummaries() {
         return importSummaries;
+    }
+
+    public List<Conflict> getConflicts() {
+        return conflicts;
     }
 
     @Override

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/event/EventApiClient.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/event/EventApiClient.java
@@ -31,9 +31,11 @@ package org.hisp.dhis.client.sdk.core.event;
 import org.hisp.dhis.client.sdk.core.common.Fields;
 import org.hisp.dhis.client.sdk.core.common.network.ApiException;
 import org.hisp.dhis.client.sdk.core.common.network.ApiMessage;
+import org.hisp.dhis.client.sdk.models.common.importsummary.ImportSummary;
 import org.hisp.dhis.client.sdk.models.event.Event;
 import org.joda.time.DateTime;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -45,7 +47,7 @@ public interface EventApiClient {
 
     ApiMessage postEvents(List<Event> events) throws ApiException;
 
-    List<ApiMessage> putEvents(List<Event> events) throws ApiException;
+    List<ImportSummary> putEvents(List<Event> events) throws ApiException;
 
     ApiMessage deleteEvent(Event event) throws ApiException;
 }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/event/EventApiClient.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/event/EventApiClient.java
@@ -45,5 +45,7 @@ public interface EventApiClient {
 
     ApiMessage postEvents(List<Event> events) throws ApiException;
 
+    List<ApiMessage> putEvents(List<Event> events) throws ApiException;
+
     ApiMessage deleteEvent(Event event) throws ApiException;
 }

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/event/EventControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/event/EventControllerImpl.java
@@ -225,10 +225,7 @@ public final class EventControllerImpl extends AbsDataController<Event> implemen
                 System.out.println("ApiResponse: " + apiMessage);
                 importSummaries = apiMessage.getResponse().getImportSummaries();
             } else if (action.equals(Action.TO_UPDATE)){
-                List<ApiMessage> apiMessages =  eventApiClient.putEvents(events);
-                for(ApiMessage apiMessage : apiMessages){
-                    importSummaries.addAll(apiMessage.getResponse().getImportSummaries());
-                }
+                importSummaries =  eventApiClient.putEvents(events);
             }
 
             Map<String, Event> eventMap = ModelUtils.toMap(events);

--- a/core/src/main/java/org/hisp/dhis/client/sdk/core/event/EventControllerImpl.java
+++ b/core/src/main/java/org/hisp/dhis/client/sdk/core/event/EventControllerImpl.java
@@ -189,12 +189,20 @@ public final class EventControllerImpl extends AbsDataController<Event> implemen
     public List<ImportSummary> push(Set<String> uids) throws ApiException {
         isEmpty(uids, "Set of event uids must not be null");
 
-        List <ImportSummary> importSummaries = sendEvents(uids);
+        List <ImportSummary> importSummaries = sendEvents(uids, Action.TO_POST);
         //deleteEvents(uids);
         return importSummaries;
     }
 
-    private List<ImportSummary> sendEvents(Set<String> eventUids) throws ApiException {
+    @Override
+    public List<ImportSummary> push(Set<String> uids, Action action) throws ApiException {
+        isEmpty(uids, "Set of event uids must not be null");
+        List<ImportSummary> importSummaries = sendEvents(uids, action);
+        //deleteEvents(uids);
+        return importSummaries;
+    }
+
+    private List<ImportSummary> sendEvents(Set<String> eventUids, Action action) throws ApiException {
         // retrieve basic events with given state from database
 
         //TODO  Implement the action event states
@@ -209,12 +217,20 @@ public final class EventControllerImpl extends AbsDataController<Event> implemen
 
         List<Event> events = eventStore.queryByUids(eventUids);
 
+
         try {
-            ApiMessage apiMessage = eventApiClient.postEvents(events);
+            List<ImportSummary> importSummaries = new ArrayList<>();
+            if(action.equals(Action.TO_POST)) {
+                ApiMessage apiMessage = eventApiClient.postEvents(events);
+                System.out.println("ApiResponse: " + apiMessage);
+                importSummaries = apiMessage.getResponse().getImportSummaries();
+            } else if (action.equals(Action.TO_UPDATE)){
+                List<ApiMessage> apiMessages =  eventApiClient.putEvents(events);
+                for(ApiMessage apiMessage : apiMessages){
+                    importSummaries.addAll(apiMessage.getResponse().getImportSummaries());
+                }
+            }
 
-            System.out.println("ApiResponse: " + apiMessage);
-
-            List<ImportSummary> importSummaries = apiMessage.getResponse().getImportSummaries();
             Map<String, Event> eventMap = ModelUtils.toMap(events);
 
             // check if all items were synced successfully

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/importsummary/Conflict.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/importsummary/Conflict.java
@@ -43,6 +43,10 @@ public class Conflict {
     public Conflict() {
         // explicit empty constructor
     }
+    public Conflict(String value, String object) {
+        this.value = value;
+        this.object = object;
+    }
 
     public String getObject() {
         return object;

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/importsummary/ImportSummary.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/importsummary/ImportSummary.java
@@ -58,10 +58,11 @@ public class ImportSummary {
         // explicit empty constructor
     }
 
-    public ImportSummary(Status status, ImportCount importCount, String reference) {
+    public ImportSummary(Status status, ImportCount importCount, String reference, List<Conflict>  conflicts) {
         this.status = status;
         this.importCount = importCount;
         this.reference = reference;
+        this.conflicts = conflicts;
     }
 
     public Status getStatus() {

--- a/models/src/main/java/org/hisp/dhis/client/sdk/models/common/importsummary/ImportSummary.java
+++ b/models/src/main/java/org/hisp/dhis/client/sdk/models/common/importsummary/ImportSummary.java
@@ -58,6 +58,12 @@ public class ImportSummary {
         // explicit empty constructor
     }
 
+    public ImportSummary(Status status, ImportCount importCount, String reference) {
+        this.status = status;
+        this.importCount = importCount;
+        this.reference = reference;
+    }
+
     public Status getStatus() {
         return status;
     }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2126
* **Related pull-requests:**

### :tophat: What is the goal?

Push updated events with put method

### :memo: How is it being implemented?

I created a new api call to put the events, and a new method with a extra parameter to push the events, using that parameter to differentiate between new events and update events.
In the server the put Api response haven't "importsummary", and i created a constructor to set it.
I added a Conflict object inside ApiMessage to get the conflict objects to identify the conflict values when put a event with a conflict datavalue.

### :boom: How can it be tested?

 **Use case 1:**  Push a new survey.
 **Use case 1:**  Push a updated survey.

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-