### PR TITLE
Feature add categories

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/sdk/controllers/metadata/MetaDataController.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/controllers/metadata/MetaDataController.java
@@ -52,6 +52,8 @@ import org.hisp.dhis.android.sdk.persistence.models.Attribute;
 import org.hisp.dhis.android.sdk.persistence.models.Attribute$Table;
 import org.hisp.dhis.android.sdk.persistence.models.AttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.AttributeValue$Table;
+import org.hisp.dhis.android.sdk.persistence.models.CategoryOptionCombo;
+import org.hisp.dhis.android.sdk.persistence.models.CategoryOptionCombo$Table;
 import org.hisp.dhis.android.sdk.persistence.models.Conflict;
 import org.hisp.dhis.android.sdk.persistence.models.Constant;
 import org.hisp.dhis.android.sdk.persistence.models.Constant$Table;
@@ -322,6 +324,34 @@ public final class MetaDataController extends ResourceController {
             }
         }
         return programs;
+    }
+
+    /**
+     * Returns a list of category option combos assigned to the given program id
+     *
+     * @param programId
+     * @return
+     */
+    public static List<CategoryOptionCombo> getCategoryOptionComboFromProgram(String programId) {
+        Program program = new Select().from(Program.class).where(
+                Condition.column(Program$Table.ID).is(programId)).querySingle();
+
+        List<CategoryOptionCombo> plist = new Select().from(CategoryOptionCombo.class).where(
+                Condition.column(CategoryOptionCombo$Table.CATEGORYCOMBO).is(program.getCategoryComboUId()))
+                .queryList();
+        return plist;
+    }
+
+    /**
+     * Returns a list of category option combos assigned to the given program id
+     *
+     * @param programId
+     * @return
+     */
+    public static CategoryOptionCombo getCategoryOptionCombo(String categoryOptionComboId) {
+        CategoryOptionCombo categoryOptionCombo = new Select().from(CategoryOptionCombo.class).where(
+                Condition.column(CategoryOptionCombo$Table.ID).is(categoryOptionComboId)).querySingle();
+        return categoryOptionCombo;
     }
 
     public static List<ProgramStage> getProgramStages(String program) {

--- a/core/src/main/java/org/hisp/dhis/android/sdk/controllers/metadata/MetaDataController.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/controllers/metadata/MetaDataController.java
@@ -737,7 +737,9 @@ public final class MetaDataController extends ResourceController {
         final Map<String, String> QUERY_MAP_FULL = new HashMap<>();
 
         QUERY_MAP_FULL.put("fields",
-                "*,trackedEntity[*],programIndicators[*],programStages[*,!dataEntryForm,program[id],programIndicators[*]," +
+                "*,categoryCombo[id,created,access,lastUpdated,displayName,name,categoryOptionCombos[id,shortName,displayName,lastUpdated,created,access,name,categoryOptions]," +
+                        "categories[id,created,lastUpdated,access,name,displayName,categoryOptions[id,code,lastUpdated,created,access,displayName,shortName,name]]]," +
+                        "trackedEntity[*],programIndicators[*],programStages[*,!dataEntryForm,program[id],programIndicators[*]," +
                         "programStageSections[*,programStageDataElements[*,programStage[id]," +
                         "dataElement[*,id,attributeValues[*,attribute[*]],optionSet[id]]],programIndicators[*]],programStageDataElements" +
                         "[*,programStage[id],dataElement[*,optionSet[id]]]],programTrackedEntityAttributes" +

--- a/core/src/main/java/org/hisp/dhis/android/sdk/controllers/tracker/TrackerController.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/controllers/tracker/TrackerController.java
@@ -200,6 +200,23 @@ public final class TrackerController extends ResourceController {
     }
 
     /**
+     * Returns a list of events for a given org unit and program
+     *
+     * @param organisationUnitId
+     * @param programId
+     * @return
+     */
+    public static List<Event> getNotDeletedEvents(String organisationUnitId, String programId,String attributeCC) {
+        List<Event> events = new Select().from(Event.class).where(Condition.column
+                (Event$Table.ORGANISATIONUNITID).is(organisationUnitId)).
+                and(Condition.column(Event$Table.PROGRAMID).is(programId)).
+                and(Condition.column(Event$Table.ATTRIBUTECC).is(attributeCC)).
+                and(Condition.column(Event$Table.STATUS).isNot(Event.STATUS_DELETED))
+                .orderBy(false, Event$Table.LASTUPDATED).queryList();
+        return events;
+    }
+
+    /**
      * Returns a list of events for a given org unit and from server
      *
      * @return

--- a/core/src/main/java/org/hisp/dhis/android/sdk/controllers/tracker/TrackerDataLoader.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/controllers/tracker/TrackerDataLoader.java
@@ -118,14 +118,10 @@ final class TrackerDataLoader extends ResourceController {
                         UiUtils.postProgressMessage(context.getString(R.string.loading_events) + ": "
                                 + organisationUnit.getLabel() + ": " + program.getName(), LoadingMessageEvent.EventType.DATA);
                         try {
-                            if(program.getCategoryCombo() == null){
-                                getEventsDataFromServer(dhisApi, syncStrategy, organisationUnit.getId(), program.getUid(), "", "", serverDateTime);
-                            }else {
-                                for (CategoryOptionCombo categoryOptionCombo : program.getCategoryCombo().getCategoryOptionCombos()){
+                            for (CategoryOptionCombo categoryOptionCombo : program.getCategoryCombo().getCategoryOptionCombos()){
 
-                                    getEventsDataFromServer(dhisApi, syncStrategy, organisationUnit.getId(), program.getUid(),
-                                            categoryOptionCombo.getCategoryCombo(), categoryOptionCombo.getCategoryOption(), serverDateTime);
-                                }
+                                getEventsDataFromServer(dhisApi, syncStrategy, organisationUnit.getId(), program.getUid(),
+                                        categoryOptionCombo.getCategoryCombo(), categoryOptionCombo.getCategoryOption(), serverDateTime);
                             }
                         } catch (APIException e) {
                         e.printStackTrace();

--- a/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/Category.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/Category.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.sdk.persistence.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.raizlabs.android.dbflow.annotation.Table;
+
+import org.hisp.dhis.android.sdk.persistence.Dhis2Database;
+
+import java.util.List;
+
+@Table(databaseName = Dhis2Database.NAME)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class Category extends BaseMetaDataObject {
+
+    @JsonProperty("categoryOptions")
+    List<CategoryOption> categoryOptions;
+
+    public Category() {
+    }
+
+    public List<CategoryOption> getCategoryOptions() {
+        return categoryOptions;
+    }
+
+    public void setCategoryOptions(List<CategoryOption> categoryOptions) {
+        this.categoryOptions = categoryOptions;
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/CategoryCombo.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/CategoryCombo.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.sdk.persistence.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.raizlabs.android.dbflow.annotation.Table;
+import com.raizlabs.android.dbflow.sql.builder.Condition;
+import com.raizlabs.android.dbflow.sql.language.Select;
+
+import org.hisp.dhis.android.sdk.persistence.Dhis2Database;
+
+import java.util.List;
+
+@Table(databaseName = Dhis2Database.NAME)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class CategoryCombo extends BaseMetaDataObject {
+
+    @JsonProperty("categories")
+    List<Category> categories;
+
+    @JsonProperty("categoryOptionCombos")
+    List<CategoryOptionCombo> categoryOptionCombos;
+
+    public CategoryCombo() {
+    }
+
+    public List<Category> getCategories() {
+        return categories;
+    }
+
+    public void setCategories(List<Category> categories) {
+        this.categories = categories;
+    }
+
+    public List<CategoryOptionCombo> getCategoryOptionCombos() {
+        if (categoryOptionCombos == null) {
+            categoryOptionCombos = new Select()
+                    .from(CategoryOptionCombo.class)
+                    .where(Condition.column(CategoryOptionCombo$Table.CATEGORYCOMBO)
+                            .is(getUid())).queryList();
+        }
+        return categoryOptionCombos;
+    }
+
+    public void setCategoryOptionCombos(List<CategoryOptionCombo> categoryOptionCombos) {
+        this.categoryOptionCombos = categoryOptionCombos;
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/CategoryOption.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/CategoryOption.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.sdk.persistence.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.Table;
+
+import org.hisp.dhis.android.sdk.persistence.Dhis2Database;
+
+@Table(databaseName = Dhis2Database.NAME)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class CategoryOption extends BaseMetaDataObject {
+
+    public CategoryOption() {
+    }
+
+    @JsonProperty("code")
+    @Column(name = "code")
+    String code;
+
+    @Column(name = "categoryUId")
+    String categoryUId;
+
+    public String getCode() {
+        //return code;
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getCategoryUId() {
+        return categoryUId;
+    }
+
+    public void setCategoryUId(String categoryUId) {
+        this.categoryUId = categoryUId;
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/CategoryOptionCombo.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/CategoryOptionCombo.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016, University of Oslo
+ *
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.android.sdk.persistence.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.raizlabs.android.dbflow.annotation.Column;
+import com.raizlabs.android.dbflow.annotation.Table;
+
+import org.hisp.dhis.android.sdk.persistence.Dhis2Database;
+
+import java.util.List;
+
+@Table(databaseName = Dhis2Database.NAME)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class CategoryOptionCombo extends BaseMetaDataObject {
+
+    @JsonProperty("categoryOptions")
+    List<CategoryOption> categoryOptions;
+
+    @Column(name = "categoryCombo")
+    String categoryCombo;
+    @Column(name = "categoryOption")
+    String categoryOption;
+
+    public CategoryOptionCombo() {
+    }
+
+    public List<CategoryOption> getCategoryOptions() {
+        return categoryOptions;
+    }
+
+    public void setCategoryOptions(List<CategoryOption> categoryOptions) {
+        this.categoryOptions = categoryOptions;
+    }
+
+    public String getCategoryOption() {
+        return categoryOption;
+    }
+
+    public void setCategoryOption(String categoryOption) {
+        this.categoryOption = categoryOption;
+    }
+    public String getCategoryCombo() {
+        return categoryCombo;
+    }
+
+    public void setCategoryCombo(String categoryCombo) {
+        this.categoryCombo = categoryCombo;
+    }
+}

--- a/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/Event.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/Event.java
@@ -140,10 +140,6 @@ public class Event extends BaseSerializableModel {
     @Column(name = "completedDate")
     String completedDate;
 
-    @JsonIgnore
-    @Column(name = "attributeCos")
-    String attributeCOS;
-
     @JsonProperty("attributeCategoryOptions")
     @Column(name = "attributeCC")
     String attributeCC;
@@ -405,14 +401,6 @@ public class Event extends BaseSerializableModel {
     @JsonIgnore
     public boolean isComplete(){
         return getStatus().equals(Event.STATUS_COMPLETED);
-    }
-
-    public String getAttributeCOS() {
-        return attributeCOS;
-    }
-
-    public void setAttributeCOS(String attributeCOS) {
-        this.attributeCOS = attributeCOS;
     }
 
     public String getAttributeCC() {

--- a/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/Event.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/Event.java
@@ -140,6 +140,14 @@ public class Event extends BaseSerializableModel {
     @Column(name = "completedDate")
     String completedDate;
 
+    @JsonIgnore
+    @Column(name = "attributeCos")
+    String attributeCOS;
+
+    @JsonProperty("attributeCategoryOptions")
+    @Column(name = "attributeCC")
+    String attributeCC;
+
     @JsonProperty("dataValues")
     List<DataValue> dataValues;
 
@@ -397,5 +405,21 @@ public class Event extends BaseSerializableModel {
     @JsonIgnore
     public boolean isComplete(){
         return getStatus().equals(Event.STATUS_COMPLETED);
+    }
+
+    public String getAttributeCOS() {
+        return attributeCOS;
+    }
+
+    public void setAttributeCOS(String attributeCOS) {
+        this.attributeCOS = attributeCOS;
+    }
+
+    public String getAttributeCC() {
+        return attributeCC;
+    }
+
+    public void setAttributeCC(String attributeCC) {
+        this.attributeCC = attributeCC;
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/Program.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/persistence/models/Program.java
@@ -126,6 +126,15 @@ public class Program extends BaseMetaDataObject {
     @Column(name = "selectIncidentDatesInFuture")
     boolean selectIncidentDatesInFuture;
 
+    /**
+     * Reference to lazy categoryCombo
+     */
+    @JsonProperty("categoryCombo")
+    CategoryCombo categoryCombo;
+
+    @Column(name = "categoryCombo")
+    String categoryComboUId;
+
     @JsonProperty("programStages")
     List<ProgramStage> programStages;
 
@@ -317,5 +326,31 @@ public class Program extends BaseMetaDataObject {
 
     public void setCompleteEventsExpiryDays(int completeEventsExpiryDays) {
         this.completeEventsExpiryDays = completeEventsExpiryDays;
+    }
+
+    public CategoryCombo getCategoryCombo() {
+            if (categoryCombo == null) {
+                if (categoryComboUId == null) return null;
+                categoryCombo = new Select()
+                        .from(CategoryCombo.class)
+                        .where(Condition.column(CategoryCombo$Table.ID)
+                                .is(categoryComboUId)).querySingle();
+            }
+        return categoryCombo;
+    }
+
+    public void setCategoryCombo(CategoryCombo categoryCombo) {
+        if(categoryCombo!=null){
+            this.categoryComboUId = categoryCombo.getUid();
+        }
+        this.categoryCombo = categoryCombo;
+    }
+
+    public String getCategoryComboUId() {
+        return categoryComboUId;
+    }
+
+    public void setCategoryComboUId(String categoryComboUId) {
+        this.categoryComboUId = categoryComboUId;
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/dialogs/OrgUnitDialogFragment.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/dialogs/OrgUnitDialogFragment.java
@@ -33,11 +33,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.Loader;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 
 import com.raizlabs.android.dbflow.structure.Model;
 
@@ -48,7 +44,6 @@ import org.hisp.dhis.android.sdk.persistence.loaders.Query;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnit;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnitProgramRelationship;
 import org.hisp.dhis.android.sdk.persistence.models.Program;
-import org.hisp.dhis.android.sdk.persistence.models.Program$Table;
 import org.hisp.dhis.android.sdk.ui.dialogs.AutoCompleteDialogAdapter.OptionAdapterValue;
 import org.hisp.dhis.android.sdk.utils.api.ProgramType;
 

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventDataEntryFragment.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventDataEntryFragment.java
@@ -101,6 +101,8 @@ public class EventDataEntryFragment extends DataEntryFragment<EventDataEntryFrag
     private static final String ORG_UNIT_ID = "extra:orgUnitId";
     private static final String PROGRAM_ID = "extra:ProgramId";
     private static final String PROGRAM_STAGE_ID = "extra:ProgramStageId";
+    private static final String CATEGORY_OPTION_COMBO_ID = "extra:CategoryCombo";
+    private static final String CATEGORY_OPTION_ID = "extra:CategoryOption";
     private static final String EVENT_ID = "extra:EventId";
     private static final String ENROLLMENT_ID = "extra:EnrollmentId";
     private ImageView previousSectionButton;
@@ -126,12 +128,40 @@ public class EventDataEntryFragment extends DataEntryFragment<EventDataEntryFrag
     }
 
     public static EventDataEntryFragment newInstance(String unitId, String programId, String programStageId,
-                                                long eventId) {
+                                                     String attributeCC, String attributeCOS) {
         EventDataEntryFragment fragment = new EventDataEntryFragment();
         Bundle args = new Bundle();
         args.putString(ORG_UNIT_ID, unitId);
         args.putString(PROGRAM_ID, programId);
         args.putString(PROGRAM_STAGE_ID, programStageId);
+        args.putString(CATEGORY_OPTION_COMBO_ID, attributeCC);
+        args.putString(CATEGORY_OPTION_ID, attributeCOS);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    public static EventDataEntryFragment newInstance(String unitId, String programId, String programStageId,
+                                                     long eventId) {
+        EventDataEntryFragment fragment = new EventDataEntryFragment();
+        Bundle args = new Bundle();
+        args.putString(ORG_UNIT_ID, unitId);
+        args.putString(PROGRAM_ID, programId);
+        args.putString(PROGRAM_STAGE_ID, programStageId);
+        args.putLong(EVENT_ID, eventId);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    public static EventDataEntryFragment newInstance(String unitId, String programId, String programStageId,
+                                                     String attributeCC, String attributeCOS,
+                                                     long eventId) {
+        EventDataEntryFragment fragment = new EventDataEntryFragment();
+        Bundle args = new Bundle();
+        args.putString(ORG_UNIT_ID, unitId);
+        args.putString(PROGRAM_ID, programId);
+        args.putString(PROGRAM_STAGE_ID, programStageId);
+        args.putString(CATEGORY_OPTION_COMBO_ID, attributeCC);
+        args.putString(CATEGORY_OPTION_ID, attributeCOS);
         args.putLong(EVENT_ID, eventId);
         fragment.setArguments(args);
         return fragment;
@@ -246,6 +276,8 @@ public class EventDataEntryFragment extends DataEntryFragment<EventDataEntryFrag
                     fragmentArguments.getString(ORG_UNIT_ID),
                     fragmentArguments.getString(PROGRAM_ID),
                     fragmentArguments.getString(PROGRAM_STAGE_ID),
+                    fragmentArguments.getString(CATEGORY_OPTION_COMBO_ID),
+                    fragmentArguments.getString(CATEGORY_OPTION_ID),
                     fragmentArguments.getLong(EVENT_ID, -1),
                     fragmentArguments.getLong(ENROLLMENT_ID, -1)
                 )

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventDataEntryFragment.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventDataEntryFragment.java
@@ -101,7 +101,6 @@ public class EventDataEntryFragment extends DataEntryFragment<EventDataEntryFrag
     private static final String ORG_UNIT_ID = "extra:orgUnitId";
     private static final String PROGRAM_ID = "extra:ProgramId";
     private static final String PROGRAM_STAGE_ID = "extra:ProgramStageId";
-    private static final String CATEGORY_OPTION_COMBO_ID = "extra:CategoryCombo";
     private static final String CATEGORY_OPTION_ID = "extra:CategoryOption";
     private static final String EVENT_ID = "extra:EventId";
     private static final String ENROLLMENT_ID = "extra:EnrollmentId";
@@ -128,14 +127,13 @@ public class EventDataEntryFragment extends DataEntryFragment<EventDataEntryFrag
     }
 
     public static EventDataEntryFragment newInstance(String unitId, String programId, String programStageId,
-                                                     String attributeCC, String attributeCOS) {
+                                                     String attributeCC) {
         EventDataEntryFragment fragment = new EventDataEntryFragment();
         Bundle args = new Bundle();
         args.putString(ORG_UNIT_ID, unitId);
         args.putString(PROGRAM_ID, programId);
         args.putString(PROGRAM_STAGE_ID, programStageId);
-        args.putString(CATEGORY_OPTION_COMBO_ID, attributeCC);
-        args.putString(CATEGORY_OPTION_ID, attributeCOS);
+        args.putString(CATEGORY_OPTION_ID, attributeCC);
         fragment.setArguments(args);
         return fragment;
     }
@@ -153,15 +151,13 @@ public class EventDataEntryFragment extends DataEntryFragment<EventDataEntryFrag
     }
 
     public static EventDataEntryFragment newInstance(String unitId, String programId, String programStageId,
-                                                     String attributeCC, String attributeCOS,
-                                                     long eventId) {
+                                                     String attributeCC, long eventId) {
         EventDataEntryFragment fragment = new EventDataEntryFragment();
         Bundle args = new Bundle();
         args.putString(ORG_UNIT_ID, unitId);
         args.putString(PROGRAM_ID, programId);
         args.putString(PROGRAM_STAGE_ID, programStageId);
-        args.putString(CATEGORY_OPTION_COMBO_ID, attributeCC);
-        args.putString(CATEGORY_OPTION_ID, attributeCOS);
+        args.putString(CATEGORY_OPTION_ID, attributeCC);
         args.putLong(EVENT_ID, eventId);
         fragment.setArguments(args);
         return fragment;
@@ -276,7 +272,6 @@ public class EventDataEntryFragment extends DataEntryFragment<EventDataEntryFrag
                     fragmentArguments.getString(ORG_UNIT_ID),
                     fragmentArguments.getString(PROGRAM_ID),
                     fragmentArguments.getString(PROGRAM_STAGE_ID),
-                    fragmentArguments.getString(CATEGORY_OPTION_COMBO_ID),
                     fragmentArguments.getString(CATEGORY_OPTION_ID),
                     fragmentArguments.getLong(EVENT_ID, -1),
                     fragmentArguments.getLong(ENROLLMENT_ID, -1)

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventDataEntryFragmentQuery.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventDataEntryFragmentQuery.java
@@ -87,16 +87,14 @@ class EventDataEntryFragmentQuery implements Query<EventDataEntryFragmentForm> {
     private final String orgUnitId;
     private final String programId;
     private final String programStageId;
-    private final String attributeCOS;
     private final String attributeCC;
     private final long eventId;
     private final long enrollmentId;
 
-    EventDataEntryFragmentQuery(String orgUnitId, String programId, String programStageId, String attributeCOS, String attributeCC, long eventId, long enrollmentId) {
+    EventDataEntryFragmentQuery(String orgUnitId, String programId, String programStageId, String attributeCC, long eventId, long enrollmentId) {
         this.orgUnitId = orgUnitId;
         this.programId = programId;
         this.programStageId = programStageId;
-        this.attributeCOS = attributeCOS;
         this.attributeCC = attributeCC;
         this.eventId = eventId;
         this.enrollmentId = enrollmentId;
@@ -116,7 +114,6 @@ class EventDataEntryFragmentQuery implements Query<EventDataEntryFragmentForm> {
                 orgUnitId, programId, eventId, enrollmentId, stage, username
         );
         event.setAttributeCC(attributeCC);
-        event.setAttributeCOS(attributeCOS);
         form.setEvent(event);
         if(enrollmentId > 0) {
             Enrollment enrollment = TrackerController.getEnrollment(enrollmentId);

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventDataEntryFragmentQuery.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventDataEntryFragmentQuery.java
@@ -87,13 +87,17 @@ class EventDataEntryFragmentQuery implements Query<EventDataEntryFragmentForm> {
     private final String orgUnitId;
     private final String programId;
     private final String programStageId;
+    private final String attributeCOS;
+    private final String attributeCC;
     private final long eventId;
     private final long enrollmentId;
 
-    EventDataEntryFragmentQuery(String orgUnitId, String programId, String programStageId, long eventId, long enrollmentId) {
+    EventDataEntryFragmentQuery(String orgUnitId, String programId, String programStageId, String attributeCOS, String attributeCC, long eventId, long enrollmentId) {
         this.orgUnitId = orgUnitId;
         this.programId = programId;
         this.programStageId = programStageId;
+        this.attributeCOS = attributeCOS;
+        this.attributeCC = attributeCC;
         this.eventId = eventId;
         this.enrollmentId = enrollmentId;
     }
@@ -111,7 +115,8 @@ class EventDataEntryFragmentQuery implements Query<EventDataEntryFragmentForm> {
         final Event event = getEvent(
                 orgUnitId, programId, eventId, enrollmentId, stage, username
         );
-
+        event.setAttributeCC(attributeCC);
+        event.setAttributeCOS(attributeCOS);
         form.setEvent(event);
         if(enrollmentId > 0) {
             Enrollment enrollment = TrackerController.getEnrollment(enrollmentId);

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventSaveThread.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventSaveThread.java
@@ -94,7 +94,6 @@ public class EventSaveThread extends AsyncHelperThread {
         saveEvent = false;
         event.setFromServer(false);
         Event tempEvent = new Event();
-        tempEvent.setAttributeCOS(event.getAttributeCOS());
         tempEvent.setAttributeCC(event.getAttributeCC());
         tempEvent.setLocalId(event.getLocalId());
         tempEvent.setEvent(event.getEvent());

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventSaveThread.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/eventdataentry/EventSaveThread.java
@@ -94,6 +94,8 @@ public class EventSaveThread extends AsyncHelperThread {
         saveEvent = false;
         event.setFromServer(false);
         Event tempEvent = new Event();
+        tempEvent.setAttributeCOS(event.getAttributeCOS());
+        tempEvent.setAttributeCC(event.getAttributeCC());
         tempEvent.setLocalId(event.getLocalId());
         tempEvent.setEvent(event.getEvent());
         tempEvent.setStatus(event.getStatus());

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/selectprogram/SelectProgramFragment.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/selectprogram/SelectProgramFragment.java
@@ -350,7 +350,7 @@ public abstract class SelectProgramFragment extends Fragment
             if (!backedUpState.isCategoryOptionComboEmpty()) {
                 onCategoryOptionComboSelected(
                         backedUpState.getCategoryOptionComboId(),
-                        backedUpState.getProgramName()
+                        backedUpState.getCategoryOptionComboName()
                 );
             }
         }

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/selectprogram/SelectProgramFragmentPreferences.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/selectprogram/SelectProgramFragmentPreferences.java
@@ -37,9 +37,12 @@ import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Select;
 
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
+import org.hisp.dhis.android.sdk.persistence.models.CategoryOptionCombo;
+import org.hisp.dhis.android.sdk.persistence.models.Program$Table;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnit;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnitProgramRelationship;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnitProgramRelationship$Table;
+import org.hisp.dhis.android.sdk.persistence.models.Program;
 
 import static org.hisp.dhis.android.sdk.utils.Preconditions.isNull;
 
@@ -54,6 +57,9 @@ public final class SelectProgramFragmentPreferences {
 
     private static final String PROGRAM_ID = "key:programId";
     private static final String PROGRAM_LABEL = "key:programLabel";
+
+    private static final String CATEGORY_OPTION_COMBO_ID = "key:categoryOptionComboId";
+    private static final String CATEGORY_OPTION_COMBO_LABEL = "key:categoryOptionComboLabel";
 
     private final SharedPreferences mPrefs;
 
@@ -78,6 +84,8 @@ public final class SelectProgramFragmentPreferences {
         remove(ORG_UNIT_LABEL);
         remove(PROGRAM_ID);
         remove(PROGRAM_LABEL);
+        remove(CATEGORY_OPTION_COMBO_ID);
+        remove(CATEGORY_OPTION_COMBO_LABEL);
     }
 
     public Pair<String, String> getOrgUnit() {
@@ -120,6 +128,31 @@ public final class SelectProgramFragmentPreferences {
             return new Pair<>(programId, programLabel);
         } else {
             putProgram(null);
+            return null;
+        }
+    }
+
+    public void putCategoryOptionCombo(Pair<String, String> categoryOptionCombo) {
+        if (categoryOptionCombo != null) {
+            put(CATEGORY_OPTION_COMBO_ID, categoryOptionCombo.first);
+            put(CATEGORY_OPTION_COMBO_LABEL, categoryOptionCombo.second);
+        } else {
+            remove(CATEGORY_OPTION_COMBO_ID);
+            remove(CATEGORY_OPTION_COMBO_LABEL);
+        }
+    }
+
+    public Pair<String, String> getCategoryOptionCombo() {
+        String programId = get(PROGRAM_ID);
+        String categoryOptionComboID = get(CATEGORY_OPTION_COMBO_ID);
+        String categoryOptionComboLabel = get(CATEGORY_OPTION_COMBO_LABEL);
+
+        Program program = new Select().count().from(Program.class).where(
+                Condition.column(Program$Table.ID).is(programId)).querySingle();
+        if(program!=null && program.getCategoryCombo()!=null){
+            return new Pair<>(categoryOptionComboID, categoryOptionComboLabel);
+        } else {
+            putCategoryOptionCombo(null);
             return null;
         }
     }

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/selectprogram/SelectProgramFragmentState.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/selectprogram/SelectProgramFragmentState.java
@@ -53,6 +53,9 @@ public class SelectProgramFragmentState implements Parcelable {
     private String programName;
     private String programId;
 
+    private String categoryOptionComboName;
+    private String categoryOptionComboId;
+
     public SelectProgramFragmentState() {
     }
 
@@ -72,6 +75,9 @@ public class SelectProgramFragmentState implements Parcelable {
 
         programName = in.readString();
         programId = in.readString();
+
+        categoryOptionComboName = in.readString();
+        categoryOptionComboId = in.readString();
     }
 
     @Override
@@ -88,6 +94,9 @@ public class SelectProgramFragmentState implements Parcelable {
 
         parcel.writeString(programName);
         parcel.writeString(programId);
+
+        parcel.writeString(categoryOptionComboName);
+        parcel.writeString(categoryOptionComboId);
     }
 
     public boolean isSyncInProcess() {
@@ -140,5 +149,27 @@ public class SelectProgramFragmentState implements Parcelable {
 
     public String getProgramId() {
         return programId;
+    }
+
+    public void setCategoryOptionCombo(String categoryOptionComboId, String categoryOptionComboLabel) {
+        this.categoryOptionComboId = categoryOptionComboId;
+        this.categoryOptionComboName = categoryOptionComboLabel;
+    }
+
+    public void resetCategoryOptionCombo() {
+        categoryOptionComboId = null;
+        categoryOptionComboName = null;
+    }
+
+    public boolean isCategoryOptionComboEmpty() {
+        return (categoryOptionComboId == null || categoryOptionComboName == null);
+    }
+
+    public String getCategoryOptionComboName() {
+        return categoryOptionComboName;
+    }
+
+    public String getCategoryOptionComboId() {
+        return categoryOptionComboId;
     }
 }

--- a/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/selectprogram/SelectProgramFragmentState.java
+++ b/core/src/main/java/org/hisp/dhis/android/sdk/ui/fragments/selectprogram/SelectProgramFragmentState.java
@@ -56,6 +56,8 @@ public class SelectProgramFragmentState implements Parcelable {
     private String categoryOptionComboName;
     private String categoryOptionComboId;
 
+    private String categoryName;
+
     public SelectProgramFragmentState() {
     }
 
@@ -64,6 +66,7 @@ public class SelectProgramFragmentState implements Parcelable {
             setSyncInProcess(state.isSyncInProcess());
             setOrgUnit(state.getOrgUnitId(), state.getOrgUnitLabel());
             setProgram(state.getProgramId(), state.getProgramName());
+            setCategoryOptionCombo(state.getCategoryOptionComboId(), state.getCategoryOptionComboName());
         }
     }
 
@@ -78,6 +81,8 @@ public class SelectProgramFragmentState implements Parcelable {
 
         categoryOptionComboName = in.readString();
         categoryOptionComboId = in.readString();
+
+        categoryName = in.readString();
     }
 
     @Override
@@ -97,6 +102,8 @@ public class SelectProgramFragmentState implements Parcelable {
 
         parcel.writeString(categoryOptionComboName);
         parcel.writeString(categoryOptionComboId);
+
+        parcel.writeString(categoryName);
     }
 
     public boolean isSyncInProcess() {
@@ -171,5 +178,13 @@ public class SelectProgramFragmentState implements Parcelable {
 
     public String getCategoryOptionComboId() {
         return categoryOptionComboId;
+    }
+
+    public void setCategoryName(String name) {
+        categoryName = name;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
     }
 }

--- a/core/src/main/res/layout/fragment_select_program_header.xml
+++ b/core/src/main/res/layout/fragment_select_program_header.xml
@@ -47,6 +47,14 @@
         android:layout_marginBottom="4dp"
         app:hint="@string/choose_program" />
 
+    <org.hisp.dhis.android.sdk.ui.views.CardTextViewButton
+        android:id="@+id/select_category"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
+        android:visibility="gone"
+        app:hint="@string/choose_category" />
+
     <org.hisp.dhis.android.sdk.ui.views.FloatingActionButton
         android:id="@+id/register_new_event"
         android:layout_width="wrap_content"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="date_format">yyyy-mm-dd</string>
     <string name="dialog_organisation_units">Organisation units</string>
     <string name="dialog_programs">Programs</string>
+    <string name="dialog_categories">Categories</string>
 
     <string name="please_enter">Please enter</string>
 
@@ -195,6 +196,7 @@
     <string name="report_date">Report date</string>
     <string name="choose_organisation_unit">Choose organisation unit</string>
     <string name="choose_program">Choose program</string>
+    <string name="choose_category">Choose category</string>
     <string name="duedate">Due date</string>
     <string name="eventname">Event name</string>
     <string name="startdate">Start date</string>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/dhis2-android-eventcapture/issues/105
* **Required pull-requests: https://github.com/EyeSeeTea/dhis2-android-eventcapture/pull/106** 
### :tophat: What is the goal?

 Download on pull the category combinations associated to a program as attributes if defined

  Add a filter when selecting the OU & program if the program has a category combination different from 
the default one, so the user can select the category option combination

  On push, include in the URL the category combination used for pushing

  On event pull, add category combinations

Updating all the sdk calls to use the category combo

### :memo: How is it being implemented?

I added the new models, and new attributes into program and event models.

I added into program pull, the program category combo and his categoryOptionCombo and categories in a single call, and persist all in database.

I modify the pull of events to pull the events for each combination of program, orgunit, and program categorycombo(attributeCC->category option attributeCos -> category combo.

I added the category spinner, i followed the code for orgunit and program spinner to create the category spinner.

### :boom: How can it be tested?

- [ ] **Use case 1:** Login and use categories to see the downloaded events, and to push new events.

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [x] Nope, the client will install from zero this release
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
