### PR TITLE
Use implementation or api and fix buildToolsVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,10 @@
 
 ext {
     configuration = [
-            buildToolsVersion: "25.0.3",
+            buildToolsVersion: "28.0.3",
             minSdkVersion    : 15,
-            compileSdkVersion: 24,
-            targetSdkVersion : 24,
+            compileSdkVersion: 26,
+            targetSdkVersion : 26,
             versionCode      : 1,
             versionName      : "0.1"
     ]
@@ -42,7 +42,7 @@ ext {
 
             // android libs
             supportVersion     : "25.1.0",
-            rxAndroidVersion   : "1.1.0",
+            rxAndroidVersion   : "1.2.1",
             dbFlowVersion      : "3.0.1",
             progressBarVersion : "1.2.0",
 
@@ -69,7 +69,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }

--- a/core-android/build.gradle
+++ b/core-android/build.gradle
@@ -58,29 +58,29 @@ android {
 }
 
 dependencies {
-    compile project(":core")
+    api project(":core")
 
     // Google
-    compile "com.android.support:support-annotations:${libs.supportVersion}"
+    api "com.android.support:support-annotations:${libs.supportVersion}"
 
     // Square
-    compile "com.squareup.okhttp3:okhttp:${libs.okhttpVersion}"
-    compile "com.squareup.retrofit2:retrofit:${libs.retrofitVersion}"
-    compile "com.squareup.retrofit2:converter-jackson:${libs.retrofitVersion}"
+    implementation "com.squareup.okhttp3:okhttp:${libs.okhttpVersion}"
+    implementation "com.squareup.retrofit2:retrofit:${libs.retrofitVersion}"
+    implementation "com.squareup.retrofit2:converter-jackson:${libs.retrofitVersion}"
 
     // ReactiveX
-    compile "io.reactivex:rxandroid:${libs.rxAndroidVersion}";
+    api "io.reactivex:rxandroid:${libs.rxAndroidVersion}";
 
     // Raizlabs.
     annotationProcessor "com.github.agrosner.dbflow:dbflow-processor:${libs.dbFlowVersion}"
-    compile "com.github.agrosner.dbflow:dbflow:${libs.dbFlowVersion}"
-    compile "com.github.agrosner.dbflow:dbflow-core:${libs.dbFlowVersion}"
-    compile "com.github.agrosner.dbflow:dbflow-sqlcipher:${libs.dbFlowVersion}"
+    api "com.github.agrosner.dbflow:dbflow:${libs.dbFlowVersion}"
+    api "com.github.agrosner.dbflow:dbflow-core:${libs.dbFlowVersion}"
+    api "com.github.agrosner.dbflow:dbflow-sqlcipher:${libs.dbFlowVersion}"
 
     // Test
-    testCompile "junit:junit:${libs.jUnitVersion}"
+    testImplementation "junit:junit:${libs.jUnitVersion}"
 
     // Needed to compile from jars
-    compile "com.squareup:javapoet:${libs.javapoetVersion}"
-    compile "com.google.guava:guava:${libs.guavaVersion}"
+    implementation "com.squareup:javapoet:${libs.javapoetVersion}"
+    implementation "com.google.guava:guava:${libs.guavaVersion}"
 }

--- a/core-rules/build.gradle
+++ b/core-rules/build.gradle
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 
 def cfg = rootProject.ext.configuration
 def libs = rootProject.ext.libraries
@@ -35,20 +35,20 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-    compile project(":models")
+    implementation project(":models")
 
-    compile "org.hisp.dhis:dhis2-support-commons:${libs.dhisCommonsVersion}"
-    compile("org.apache.commons:commons-jexl:${libs.jexlVersion}") {
+    implementation "org.hisp.dhis:dhis2-support-commons:${libs.dhisCommonsVersion}"
+    implementation("org.apache.commons:commons-jexl:${libs.jexlVersion}") {
         exclude module: 'commons-logging'
     }
 
     // Test compile dependencies.
-    testCompile "junit:junit:${libs.jUnitVersion}"
-    testCompile "org.mockito:mockito-core:${libs.mockitoVersion}"
+    testImplementation "junit:junit:${libs.jUnitVersion}"
+    testImplementation "org.mockito:mockito-core:${libs.mockitoVersion}"
 
     // Square
-    testCompile "com.squareup.okhttp3:okhttp:${libs.okhttpVersion}"
-    testCompile "com.squareup.okhttp3:logging-interceptor:${libs.okhttpVersion}"
-    testCompile "com.squareup.retrofit2:retrofit:${libs.retrofitVersion}"
-    testCompile "com.squareup.retrofit2:converter-jackson:${libs.retrofitVersion}"
+    testImplementation "com.squareup.okhttp3:okhttp:${libs.okhttpVersion}"
+    testImplementation "com.squareup.okhttp3:logging-interceptor:${libs.okhttpVersion}"
+    testImplementation "com.squareup.retrofit2:retrofit:${libs.retrofitVersion}"
+    testImplementation "com.squareup.retrofit2:converter-jackson:${libs.retrofitVersion}"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -34,11 +34,11 @@ targetCompatibility = JavaVersion.VERSION_1_7
 def libs = rootProject.ext.libraries
 
 dependencies {
-    compile project(":models")
+    api project(":models")
 
     // Test compile dependencies.
-    testCompile "junit:junit:${libs.jUnitVersion}"
-    testCompile "org.mockito:mockito-core:${libs.mockitoVersion}"
-    testCompile "org.powermock:powermock-api-mockito:${libs.powerMockVersion}"
-    testCompile "org.powermock:powermock-module-junit4:${libs.powerMockVersion}"
+    testImplementation "junit:junit:${libs.jUnitVersion}"
+    testImplementation "org.mockito:mockito-core:${libs.mockitoVersion}"
+    testImplementation "org.powermock:powermock-api-mockito:${libs.powerMockVersion}"
+    testImplementation "org.powermock:powermock-module-junit4:${libs.powerMockVersion}"
 }

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -27,7 +27,7 @@
  */
 
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -35,18 +35,18 @@ targetCompatibility = JavaVersion.VERSION_1_7
 def libs = rootProject.ext.libraries
 
 dependencies {
-    compile project(":utils")
+    api project(":utils")
 
     // Fasterxml libraries.
-    compile "com.fasterxml.jackson.core:jackson-annotations:${libs.jacksonVersion}"
-    compile "com.fasterxml.jackson.core:jackson-core:${libs.jacksonVersion}"
-    compile "com.fasterxml.jackson.core:jackson-databind:${libs.jacksonVersion}"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:${libs.jacksonVersion}"
+    api "com.fasterxml.jackson.core:jackson-annotations:${libs.jacksonVersion}"
+    api "com.fasterxml.jackson.core:jackson-core:${libs.jacksonVersion}"
+    api "com.fasterxml.jackson.core:jackson-databind:${libs.jacksonVersion}"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-joda:${libs.jacksonVersion}"
 
     // Joda libraries.
-    compile "joda-time:joda-time:${libs.jodaTimeVersion}"
+    api "joda-time:joda-time:${libs.jodaTimeVersion}"
 
     // Test compile dependencies.
-    testCompile "junit:junit:${libs.jUnitVersion}"
-    testCompile "org.mockito:mockito-core:${libs.mockitoVersion}"
+    testImplementation "junit:junit:${libs.jUnitVersion}"
+    testImplementation "org.mockito:mockito-core:${libs.mockitoVersion}"
 }

--- a/ui-bindings/build.gradle
+++ b/ui-bindings/build.gradle
@@ -33,12 +33,12 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 
-    compile project(":ui")
-    compile project(":core-android")
+    api project(":ui")
+    api project(":core-android")
 
     // Square dependencies
-    compile "com.squareup.okhttp3:logging-interceptor:${libs.okhttpVersion}"
-    compile "com.squareup:javapoet:${libs.javapoetVersion}"
+    implementation "com.squareup.okhttp3:logging-interceptor:${libs.okhttpVersion}"
+    implementation "com.squareup:javapoet:${libs.javapoetVersion}"
 }

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -56,23 +56,23 @@ android {
 
 dependencies {
     // Local
-    compile project(":utils")
+    api project(":utils")
 
     // Google
-    compile "com.android.support:support-annotations:${libs.supportVersion}"
-    compile "com.android.support:recyclerview-v7:${libs.supportVersion}"
-    compile "com.android.support:preference-v7:${libs.supportVersion}"
-    compile "com.android.support:preference-v14:${libs.supportVersion}"
-    compile "com.android.support:appcompat-v7:${libs.supportVersion}"
-    compile "com.android.support:cardview-v7:${libs.supportVersion}"
-    compile "com.android.support:percent:${libs.supportVersion}"
-    compile "com.android.support:design:${libs.supportVersion}"
+    api "com.android.support:support-annotations:${libs.supportVersion}"
+    api "com.android.support:recyclerview-v7:${libs.supportVersion}"
+    api "com.android.support:preference-v7:${libs.supportVersion}"
+    api "com.android.support:preference-v14:${libs.supportVersion}"
+    api "com.android.support:appcompat-v7:${libs.supportVersion}"
+    api "com.android.support:cardview-v7:${libs.supportVersion}"
+    api "com.android.support:percent:${libs.supportVersion}"
+    api "com.android.support:design:${libs.supportVersion}"
 
     // Other
-    compile "com.github.castorflex.smoothprogressbar:library-circular:${libs.progressBarVersion}"
+    api "com.github.castorflex.smoothprogressbar:library-circular:${libs.progressBarVersion}"
 
     // Test
-    testCompile "junit:junit:${libs.jUnitVersion}"
+    testImplementation "junit:junit:${libs.jUnitVersion}"
 
-    compile 'com.bignerdranch.android:expandablerecyclerview:3.0.0-RC1'
+    api 'com.bignerdranch.android:expandablerecyclerview:3.0.0-RC1'
 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-apply plugin: 'java'
+apply plugin: 'java-library'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2308
* **Related pull-requests:**
https://github.com/EyeSeeTea/malariapp/pull/2309
https://github.com/EyeSeeTea/sdk/pull/23

###   :gear: branches 
**app**: 
       Origin: feature/fix_build_gradle_warnings Target: v1.5_hnqis
**bugshaker-android**: 
       Origin: downgrade_gradle_version  
**EyeSeeTea-SDK**: 
       Origin: feature/fix_build_gradle_warnings  Target: development
**SDK**: 
       Origin: feature/fix_build_gradle_warnings Target: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Remove build.gradle warnings

### :memo: How is it being implemented?

- I have replaced compile by implementation or api
- I have upgrade  buildToolsVersion to '28.0.3'
- I have modified java plugin to java-library to use api 

Api is used to expose dependencies to consumer  https://docs.gradle.org/current/userguide/java_library_plugin.html

### :boom: How can it be tested?

Related warnings should not appear

 **Use case 1:** - Execute malaria app and should work successfully (login, pull, push, create surveys etc..) 

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
