### PR TITLE
Remove unused dbflow-sqlcipher dependency:

### DIFF
--- a/core-android/build.gradle
+++ b/core-android/build.gradle
@@ -75,7 +75,6 @@ dependencies {
     annotationProcessor "com.github.agrosner.dbflow:dbflow-processor:${libs.dbFlowVersion}"
     compile "com.github.agrosner.dbflow:dbflow:${libs.dbFlowVersion}"
     compile "com.github.agrosner.dbflow:dbflow-core:${libs.dbFlowVersion}"
-    compile "com.github.agrosner.dbflow:dbflow-sqlcipher:${libs.dbFlowVersion}"
 
     // Test
     testCompile "junit:junit:${libs.jUnitVersion}"


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://github.com/EyeSeeTea/malariapp/issues/2343          
* **Related pull-requests:** 
https://github.com/EyeSeeTea/malariapp/pull/2345
https://github.com/EyeSeeTea/malariapp/pull/2346

###   :gear: branches 
**SDK**: 
       Origin: maintenance/support_64-bit-architectures Target: feature-2.30_upgrade_gradle    

### :tophat: What is the goal?

Support 64-bit architectures

### :memo: How is it being implemented?

According to Android documentation https://developer.android.com/distribute/best-practices/develop/64-bit, to support 64-bit architectures your apk should include 64-bit versions of native C/C++ code o libraries if exists native code.

I have analyzed the APK and the dbflow-sqlcipher dependency (version 3) included native code only for 32-bits but I think these library is not using .

I have removed this dependency and native code disappear from apk.

I have tested the 32-bit app version and the 64-bit version and seems to work correctly 

### :boom: How can it be tested?

**UseCase 1**: Execute the app normally (32-bit version) and the app should work (pull, push, create surveys etc..)

**UseCase 2**: generate apk and install on 64-bit supported device executing `adb install --abi arm64-v8a YOUR_APK_FILE.apk` and the app should work (pull, push, create surveys etc..)

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-