### PR TITLE
Feature/bring last changes in 1 3 2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,8 +41,8 @@ ext {
             buildToolsVersion: "29.0.3",
             minSdkVersion    : 19,
             targetSdkVersion : 29,
-            versionCode      : 231,
-            versionName      : "1.3.1"
+            versionCode      : 232,
+            versionName      : "1.3.2"
     ]
 
     libraries = [

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -29,8 +29,8 @@
 # Properties which are consumed by plugins/gradle-mvn-push.gradle plugin.
 # They are used for publishing artifact to snapshot repository.
 
-VERSION_NAME=1.3.1
-VERSION_CODE=231
+VERSION_NAME=1.3.2
+VERSION_CODE=232
 
 GROUP=org.hisp.dhis
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
@@ -136,17 +136,15 @@ class TrackedEntityInstanceQueryBuilderFactory {
         if (params.orgUnits().size() > 0) {
             ouMode = OrganisationUnitMode.SELECTED;
             orgUnits = params.orgUnits();
+        } else if (params.uids().size() > 0) {
+            ouMode = OrganisationUnitMode.ACCESSIBLE;
+            orgUnits = Collections.emptyList();
         } else if (hasLimitByOrgUnit) {
             ouMode = OrganisationUnitMode.SELECTED;
             orgUnits = getLinkedCaptureOrgUnitUids(programUid);
         } else {
-            if (params.uids().isEmpty()) {
-                ouMode = OrganisationUnitMode.DESCENDANTS;
-                orgUnits = getRootCaptureOrgUnitUids();
-            } else {
-                ouMode = OrganisationUnitMode.ACCESSIBLE;
-                orgUnits = Collections.emptyList();
-            }
+            ouMode = OrganisationUnitMode.DESCENDANTS;
+            orgUnits = getRootCaptureOrgUnitUids();
         }
 
         List<TeiQuery.Builder> builders = new ArrayList<>();

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
@@ -140,13 +140,18 @@ class TrackedEntityInstanceQueryBuilderFactory {
             ouMode = OrganisationUnitMode.SELECTED;
             orgUnits = getLinkedCaptureOrgUnitUids(programUid);
         } else {
-            ouMode = OrganisationUnitMode.DESCENDANTS;
-            orgUnits = getRootCaptureOrgUnitUids();
+            if (params.uids().isEmpty()) {
+                ouMode = OrganisationUnitMode.DESCENDANTS;
+                orgUnits = getRootCaptureOrgUnitUids();
+            } else {
+                ouMode = OrganisationUnitMode.ACCESSIBLE;
+                orgUnits = Collections.emptyList();
+            }
         }
 
         List<TeiQuery.Builder> builders = new ArrayList<>();
 
-        if (hasLimitByOrgUnit) {
+        if (hasLimitByOrgUnit && !orgUnits.isEmpty()) {
             for (String orgUnitUid : orgUnits) {
                 builders.add(getBuilderFor(lastUpdated, Collections.singletonList(orgUnitUid), ouMode, params, limit)
                         .program(programUid).programStatus(programStatus).programStartDate(programStartDate));

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/internal/TrackedEntityInstanceQueryBuilderFactory.java
@@ -180,6 +180,9 @@ class TrackedEntityInstanceQueryBuilderFactory {
         if (params.orgUnits().size() > 0) {
             ouMode = OrganisationUnitMode.SELECTED;
             orgUnits = params.orgUnits();
+        } else if (params.uids().size() > 0) {
+            ouMode = OrganisationUnitMode.ACCESSIBLE;
+            orgUnits = Collections.emptyList();
         } else if (hasLimitByOrgUnit) {
             ouMode = OrganisationUnitMode.SELECTED;
             orgUnits = getCaptureOrgUnitUids();
@@ -190,7 +193,7 @@ class TrackedEntityInstanceQueryBuilderFactory {
 
         List<TeiQuery.Builder> builders = new ArrayList<>();
 
-        if (hasLimitByOrgUnit) {
+        if (hasLimitByOrgUnit && !orgUnits.isEmpty()) {
             for (String orgUnitUid : orgUnits) {
                 builders.add(getBuilderFor(lastUpdated, Collections.singletonList(orgUnitUid), ouMode, params, limit));
             }

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallFactory.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallFactory.java
@@ -79,8 +79,9 @@ class TrackedEntityInstanceQueryCallFactory {
         String assignedUserModeStr = query.assignedUserMode() == null ? null : query.assignedUserMode().toString();
         String enrollmentStatus = query.enrollmentStatus() == null ? null : query.enrollmentStatus().toString();
         String eventStatus = query.eventStatus() == null ? null : query.eventStatus().toString();
+        String orgUnits = query.orgUnits().isEmpty() ? null :
+                CollectionsHelper.joinCollectionWithSeparator(query.orgUnits(), ";");
 
-        String orgUnits = CollectionsHelper.joinCollectionWithSeparator(query.orgUnits(), ";");
         Call<SearchGrid> searchGridCall = service.query(orgUnits, orgUnitModeStr, query.program(),
                 query.formattedProgramStartDate(), query.formattedProgramEndDate(), enrollmentStatus,
                 query.formattedEventStartDate(), query.formattedEventEndDate(), eventStatus,

--- a/docs/content/developer/compatibility.md
+++ b/docs/content/developer/compatibility.md
@@ -17,3 +17,4 @@ Compatibility table between DHIS2 Android SDK library, DHIS2 core and Android SD
 | 1.2.1    | 2.29 -> 2.34     | 19 - 28     |
 | 1.3.0    | 2.29 -> 2.35     | 19 - 29     |
 | 1.3.1    | 2.29 -> 2.35     | 19 - 29     |
+| 1.3.2    | 2.29 -> 2.35     | 19 - 29     |

--- a/docs/content/developer/getting-started.md
+++ b/docs/content/developer/getting-started.md
@@ -10,7 +10,7 @@ Include dependency in build.gradle.
 
 ```gradle
 dependencies {
-    implementation "org.hisp.dhis:android-core:1.3.1"
+    implementation "org.hisp.dhis:android-core:1.3.2"
     ...
 }
 ```

--- a/docs/content/developer/known-issues.md
+++ b/docs/content/developer/known-issues.md
@@ -5,3 +5,7 @@
 ## Data set completion
 
 - In DHIS2 version 2.33.0 and 2.33.1, if a dataset is mark as uncompleted in the server, this value is not updated in the SDK. In those versions the API did not expose enough information to know if the status was complete or uncomplete.
+
+## Tracker relationships
+
+- In DHIS2 version 2.35.1, TEI relationships might fail to be downloaded at data sync. 

--- a/docs/dhis2_android_sdk_developer_guide_INDEX.md
+++ b/docs/dhis2_android_sdk_developer_guide_INDEX.md
@@ -3,11 +3,11 @@ title: 'DHIS 2 Android SDK Developer Guide'
 author: 'DHIS 2'
 date:
 year: 2021
-month: January
+month: March
 keywords: [DHIS2, Android]
 commit:
 version: master
-applicable_txt: 'Applicable to version 1.3.1'
+applicable_txt: 'Applicable to version 1.3.2'
 ---
 <!--DHIS2-SECTION-ID:index-->
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close https://app.clickup.com/t/gd8155
* **Related pull-requests:** 
 https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/62

###   :gear: branches 
       Origin: feature/bring_last_changes_in_1_3_2 Target: develop-eyeseetea
### :tophat: What is the goal?

The goal is to bring the last changes in the 1.3.2

### :memo: How is it being implemented?

- [x] - Merge and solve conflicts

### :boom: How can it be tested?

**Use case 1:** - Execute the app to do login in a server and should work

### :floppy_disk: Requires DB migration?

- [ ] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [x] Yes, it's already applied.

### :art: UI changes?

- [ ] Nope, the UI remains as beautiful as it was before!
- [x] Yeap, here you have some screenshots-