### PR TITLE
Create method in ProgramStageSection repository to order by sortOrder

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.IntegerFilterConnector;
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector;
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope;
+import org.hisp.dhis.android.core.common.IdentifiableColumns;
 import org.hisp.dhis.android.core.program.internal.ProgramStageSectionFields;
 
 import java.util.Map;
@@ -77,5 +78,10 @@ public final class ProgramStageSectionsCollectionRepository extends ReadOnlyIden
 
     public ProgramStageSectionsCollectionRepository withDataElements() {
         return cf.withChild(ProgramStageSectionFields.DATA_ELEMENTS);
+    }
+
+    public ProgramStageSectionsCollectionRepository orderBySortOrder(
+            RepositoryScope.OrderByDirection direction) {
+        return cf.withOrderBy(ProgramStageSectionTableInfo.Columns.SORT_ORDER, direction);
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/865cv2pu8
* **Related Pull request:** https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/131

###   :gear: branches 
**app**: 
       Origin: feature/create_order_by_sort_order_in_program_stage_sectionsTarget: develop-eyeseetea

### :tophat: What is the goal?

Enable new method to retrieve program stage sections ordered by sortOrder

### :memo: How is it being implemented?

- [x] Create new method to enable new order

- **Important**: This PR has been created from an old develop-eyeseetea branch (1.7.1.1) currently used by spIP flavor, but the change is small and there is no conflict to merge it in the current develop-eyeseetea (1.8.1.1)

### :boom: How can it be tested?

-https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/131

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-