### PR TITLE
[develop-eyeseetea 2.8.2] Enable query TEI by attribute without value and Tei uids filter 

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallFactory.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCallFactory.kt
@@ -28,9 +28,6 @@
 package org.hisp.dhis.android.core.trackedentity.search
 
 import dagger.Reusable
-import java.text.ParseException
-import java.util.concurrent.Callable
-import javax.inject.Inject
 import org.hisp.dhis.android.core.arch.api.executors.internal.APICallExecutor
 import org.hisp.dhis.android.core.arch.api.executors.internal.RxAPICallExecutor
 import org.hisp.dhis.android.core.event.Event
@@ -46,7 +43,11 @@ import org.hisp.dhis.android.core.systeminfo.DHISVersionManager
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.internal.TrackedEntityInstanceService
 import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryOnlineHelper.Companion.toAPIFilterFormat
+import org.hisp.dhis.android.core.trackedentity.search.TrackedEntityInstanceQueryOnlineHelper.Companion.toAPIFilterFormatWithDeleteValue
 import org.hisp.dhis.android.core.util.simpleDateFormat
+import java.text.ParseException
+import java.util.concurrent.Callable
+import javax.inject.Inject
 
 @Reusable
 internal class TrackedEntityInstanceQueryCallFactory @Inject constructor(
@@ -81,6 +82,7 @@ internal class TrackedEntityInstanceQueryCallFactory @Inject constructor(
                 )
             }
         } else {
+
             val instances = getTrackedEntityQuery(query)
             TrackerQueryResult(
                 trackedEntities = instances,
@@ -148,7 +150,7 @@ internal class TrackedEntityInstanceQueryCallFactory @Inject constructor(
             eventStatus = getEventStatus(query),
             trackedEntityType = query.trackedEntityType,
             query = query.query,
-            filter = toAPIFilterFormat(query.attributeFilter, upper = true),
+            filter = toAPIFilterFormatWithDeleteValue(query.attributeFilter, upper = true),
             assignedUserMode = query.assignedUserMode?.toString(),
             lastUpdatedStartDate = query.lastUpdatedStartDate.simpleDateFormat(),
             lastUpdatedEndDate = query.lastUpdatedEndDate.simpleDateFormat(),

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryCollectionRepository.java
@@ -459,6 +459,15 @@ public final class TrackedEntityInstanceQueryCollectionRepository
     }
 
     /**
+     * Filter by Uids.
+     *
+     * @return Repository connector
+     */
+    public ListFilterConnector<TrackedEntityInstanceQueryCollectionRepository, String> byUIds() {
+        return connectorFactory.listConnector(uIds -> scope.toBuilder().uids(uIds).build());
+    }
+
+    /**
      * Apply the filters defined in a {@link ProgramStageWorkingList}. It will overwrite previous filters in case
      * they overlap. In the same way, they could be overwritten by subsequent filters.
      *

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity.search
 
-import kotlin.collections.HashSet
 import org.hisp.dhis.android.core.arch.cache.internal.D2Cache
 import org.hisp.dhis.android.core.arch.helpers.Result
 import org.hisp.dhis.android.core.arch.repositories.children.internal.ChildrenAppender
@@ -124,8 +123,9 @@ internal class TrackedEntityInstanceQueryDataFetcher constructor(
         baseOnlineQuery: TrackedEntityInstanceQueryOnline,
         requestLoadSize: Int
     ): List<Result<TrackedEntityInstance, D2Error>> {
-        val status = onlineQueryStatusMap[baseOnlineQuery]!!
-        if (status.isExhausted) {
+        val status = onlineQueryStatusMap[baseOnlineQuery]
+
+        if (status == null || status.isExhausted) {
             return emptyList()
         }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryOnlineHelper.kt
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.android.core.trackedentity.search
 
-import javax.inject.Inject
 import org.hisp.dhis.android.core.arch.call.queries.internal.BaseQuery
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.FilterItemOperator
 import org.hisp.dhis.android.core.arch.repositories.scope.internal.RepositoryScopeFilterItem
@@ -38,6 +37,7 @@ import org.hisp.dhis.android.core.event.EventStatus
 import org.hisp.dhis.android.core.maintenance.D2Error
 import org.hisp.dhis.android.core.trackedentity.TrackedEntityInstance
 import org.hisp.dhis.android.core.trackedentity.internal.TrackerParentCallFactory
+import javax.inject.Inject
 
 internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
     private val dateFilterPeriodHelper: DateFilterPeriodHelper
@@ -120,6 +120,7 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
             includeDeleted = scope.includeDeleted(),
             trackedEntityType = scope.trackedEntityType(),
             order = toAPIOrderFormat(scope.order()),
+            uids = scope.uids()
         ).run {
             scope.program()?.let {
                 copy(
@@ -157,6 +158,25 @@ internal class TrackedEntityInstanceQueryOnlineHelper @Inject constructor(
     }
 
     companion object {
+        fun toAPIFilterFormatWithDeleteValue(items: List<RepositoryScopeFilterItem>, upper: Boolean): List<String> {
+            return items
+                .groupBy { it.key() }
+                .map { (key, items) ->
+                    val clause = items.map { item ->
+                        val operator = if (upper) item.operator().apiUpperOperator else item.operator().apiOperator
+                        val value = getAPIValue(item)
+
+                        if (value == "%DELETE%"){
+                            ""
+                        } else{
+                            ":" + operator + ":" + getAPIValue(item)
+                        }
+
+                    }
+
+                    key + clause.joinToString(separator = "")
+                }
+        }
         fun toAPIFilterFormat(items: List<RepositoryScopeFilterItem>, upper: Boolean): List<String> {
             return items
                 .groupBy { it.key() }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/860t03z8h
* **Related Pull request:** https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/141

###   :gear: branches 
**app**: 
       Origin: feature/allow_query_tei_by_att_without_value_and_uids Target: develop-eyeseetea

### :tophat: What is the goal?

Enable query TEI by attribute without value and Tei uids filter

### :memo: How is it being implemented?

- [x] Enable query TEI by attribute without value and Tei uids filter

### :boom: How can it be tested?

- The search in simprints fork should return parent and children

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-