### PR TITLE
[WIDP] feat: enable change url of current account

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationHelper.kt
@@ -54,7 +54,11 @@ internal class DatabaseConfigurationHelper @Inject constructor(
         username: String,
         encrypt: Boolean
     ): DatabasesConfiguration {
-        val newAccount = DatabaseAccount.builder()
+        val existedAccount = configuration?.accounts()?.find {
+            equalsIgnoreProtocol(it.serverUrl(), serverUrl) && it.username() == username
+        }
+
+        val newAccount = existedAccount ?: DatabaseAccount.builder()
             .username(username)
             .serverUrl(serverUrl)
             .databaseName(databaseNameGenerator.getDatabaseName(serverUrl, username, encrypt))

--- a/core/src/main/java/org/hisp/dhis/android/core/user/AccountManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/AccountManager.kt
@@ -29,7 +29,6 @@
 package org.hisp.dhis.android.core.user
 
 import io.reactivex.Observable
-import kotlin.jvm.Throws
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
 import org.hisp.dhis.android.core.maintenance.D2Error
 
@@ -44,4 +43,7 @@ interface AccountManager {
     fun deleteCurrentAccount()
 
     fun accountDeletionObservable(): Observable<AccountDeletionReason>
+
+    @Throws(D2Error::class)
+    fun changeServerUrl(newServerURL:String)
 }

--- a/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/user/internal/AccountManagerImpl.kt
@@ -32,7 +32,7 @@ import android.content.Context
 import dagger.Reusable
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
-import javax.inject.Inject
+import org.hisp.dhis.android.core.arch.api.internal.ServerURLWrapper
 import org.hisp.dhis.android.core.arch.db.access.internal.DatabaseAdapterFactory
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper
 import org.hisp.dhis.android.core.arch.storage.internal.Credentials
@@ -47,6 +47,7 @@ import org.hisp.dhis.android.core.maintenance.D2ErrorCode
 import org.hisp.dhis.android.core.maintenance.D2ErrorComponent
 import org.hisp.dhis.android.core.user.AccountDeletionReason
 import org.hisp.dhis.android.core.user.AccountManager
+import javax.inject.Inject
 
 @Reusable
 internal class AccountManagerImpl @Inject constructor(
@@ -131,4 +132,28 @@ internal class AccountManagerImpl @Inject constructor(
     override fun accountDeletionObservable(): Observable<AccountDeletionReason> {
         return accountDeletionSubject
     }
+
+    override fun changeServerUrl(newServerUrl: String) {
+        ServerURLWrapper.setServerUrl(newServerUrl)
+
+        credentialsSecureStore.setServerUrl(newServerUrl)
+
+        val credentials = credentialsSecureStore.get()
+
+        val configuration = databasesConfigurationStore.get()
+
+        val newDatabasesConfiguration = configuration.toBuilder().accounts(
+            configuration.accounts().map {
+                if (it.serverUrl() == credentials.serverUrl && it.username() == credentials.username) {
+                    it.toBuilder().serverUrl(newServerUrl).build()
+                } else {
+                    it
+                }
+            }
+        ).build()
+
+        databasesConfigurationStore.set(newDatabasesConfiguration)
+    }
+
+
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8693p4dkg
* **Related Pull request:** https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/144

###   :gear: branches 
**app**: 
       Origin: feature/enable_change_url_in_current_account Target: develop-eyeseetea_1_7_1 (WIDP SDK version)

### :tophat: What is the goal?

Enable change server URL in accounts saved in secured preferences

### :memo: How is it being implemented?

- [x] Add changeServerURL in AccountManagerImpl

### :boom: How can it be tested?

-  The change should work if you exit and enter the app

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-