### PR TITLE
Feature/fix avoid resize to download images

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
@@ -32,7 +32,6 @@ import android.util.Log
 import dagger.Reusable
 import io.reactivex.Observable
 import io.reactivex.ObservableEmitter
-import javax.inject.Inject
 import okhttp3.ResponseBody
 import org.hisp.dhis.android.core.arch.api.executors.internal.APICallExecutor
 import org.hisp.dhis.android.core.arch.api.executors.internal.RxAPICallExecutor
@@ -40,7 +39,6 @@ import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.D2ProgressManager
 import org.hisp.dhis.android.core.arch.db.stores.internal.IdentifiableDataObjectStore
 import org.hisp.dhis.android.core.arch.handlers.internal.HandlerWithTransformer
-import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.fileresource.FileResource
 import org.hisp.dhis.android.core.fileresource.FileResourceDomainType
@@ -49,6 +47,7 @@ import org.hisp.dhis.android.core.fileresource.FileResourceInternalAccessor
 import org.hisp.dhis.android.core.fileresource.FileResourceRoutine
 import org.hisp.dhis.android.core.maintenance.D2Error
 import retrofit2.Call
+import javax.inject.Inject
 
 @Reusable
 internal class FileResourceDownloadCall @Inject constructor(
@@ -92,8 +91,9 @@ internal class FileResourceDownloadCall @Inject constructor(
                         v.dataElement()!!,
                         v.period()!!,
                         v.organisationUnit()!!,
-                        v.attributeOptionCombo()!!,
-                        FileResizerHelper.Dimension.MEDIUM.name
+                        v.attributeOptionCombo()!!
+                        //Eyeseetea customization - No resize
+                        //,FileResizerHelper.Dimension.MEDIUM.name
                     )
                 },
                 getUid = { v -> v.value() }
@@ -112,8 +112,10 @@ internal class FileResourceDownloadCall @Inject constructor(
                     download = { v ->
                         fileResourceService.getFileFromTrackedEntityAttribute(
                             v.trackedEntityInstance()!!,
-                            v.trackedEntityAttribute()!!,
-                            FileResizerHelper.Dimension.MEDIUM.name
+                            v.trackedEntityAttribute()!!
+                            //Eyeseetea customization - No resize
+                            //,FileResizerHelper.Dimension.MEDIUM.name,
+
                         )
                     },
                     getUid = { v -> v.value() }
@@ -130,7 +132,8 @@ internal class FileResourceDownloadCall @Inject constructor(
                         fileResourceService.getFileFromEventValue(
                             v.event()!!,
                             v.dataElement()!!,
-                            FileResizerHelper.Dimension.MEDIUM.name
+                            //Eyeseetea customization - No resize
+                            //FileResizerHelper.Dimension.MEDIUM.name
                         )
                     },
                     getUid = { v -> v.value() }

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceService.kt
@@ -46,14 +46,16 @@ internal interface FileResourceService {
     fun getFileFromTrackedEntityAttribute(
         @Path(TRACKED_ENTITY_INSTANCE) trackedEntityInstanceUid: String,
         @Path(TRACKED_ENTITY_ATTRIBUTE) trackedEntityAttributeUid: String,
-        @Query("dimension") dimension: String
+        //Eyeseetea customization - No resize
+        //   @Query("dimension") dimension: String
     ): Call<ResponseBody>
 
     @GET("$EVENTS/files")
     fun getFileFromEventValue(
         @Query("eventUid") eventUid: String,
         @Query("dataElementUid") dataElementUid: String,
-        @Query("dimension") dimension: String
+        //Eyeseetea customization - No resize
+        //@Query("dimension") dimension: String
     ): Call<ResponseBody>
 
     @GET("$DATA_VALUES/files")
@@ -62,7 +64,8 @@ internal interface FileResourceService {
         @Query("pe") period: String,
         @Query("ou") organisationUnit: String,
         @Query("co") categoryOptionCombo: String,
-        @Query("dimension") dimension: String
+        //Eyeseetea customization - No resize
+        //@Query("dimension") dimension: String?
     ): Call<ResponseBody>
 
     companion object {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.java
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.IntegerFilterConnector;
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector;
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope;
+import org.hisp.dhis.android.core.common.IdentifiableColumns;
 import org.hisp.dhis.android.core.program.internal.ProgramStageSectionFields;
 
 import java.util.Map;
@@ -77,5 +78,10 @@ public final class ProgramStageSectionsCollectionRepository extends ReadOnlyIden
 
     public ProgramStageSectionsCollectionRepository withDataElements() {
         return cf.withChild(ProgramStageSectionFields.DATA_ELEMENTS);
+    }
+
+    public ProgramStageSectionsCollectionRepository orderBySortOrder(
+            RepositoryScope.OrderByDirection direction) {
+        return cf.withOrderBy(ProgramStageSectionTableInfo.Columns.SORT_ORDER, direction);
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8693ntn2e #8693ntn2e
* **Related Pull request:** https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/149

###   :gear: branches 
       Origin: feature/fix_avoid_resize_to_download_imagesr Target: develop-eyeseetea_1_7_1

### :tophat: What is the goal?

Avoid resize images to download

### :memo: How is it being implemented?

- [x] Remove request images using the dimension parameter 
-
### :boom: How can it be tested?

Upload an image, close account, and login and the image should have the original size

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-