### PR TITLE
[1.9.1] fix avoid resize to download images

### DIFF
--- a/core/src/main/assets/migrations/148.sql
+++ b/core/src/main/assets/migrations/148.sql
@@ -1,0 +1,4 @@
+# Add style properties in Indicator table (ANDROSDK-1688)
+
+ALTER TABLE Indicator ADD COLUMN color TEXT;
+ALTER TABLE Indicator ADD COLUMN icon TEXT;

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceDownloadCall.kt
@@ -35,7 +35,6 @@ import okhttp3.ResponseBody
 import org.hisp.dhis.android.core.arch.api.executors.internal.CoroutineAPICallExecutor
 import org.hisp.dhis.android.core.arch.call.D2Progress
 import org.hisp.dhis.android.core.arch.call.internal.D2ProgressManager
-import org.hisp.dhis.android.core.arch.helpers.FileResizerHelper
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.fileresource.FileResource
@@ -94,7 +93,8 @@ internal class FileResourceDownloadCall(
                         v.period()!!,
                         v.organisationUnit()!!,
                         v.attributeOptionCombo()!!,
-                        FileResizerHelper.Dimension.MEDIUM.name,
+                        //Eyeseetea customization - No resize
+                        //,FileResizerHelper.Dimension.MEDIUM.name
                     )
                 },
                 getUid = { v -> v.value() },
@@ -116,7 +116,8 @@ internal class FileResourceDownloadCall(
                                 fileResourceService.getImageFromTrackedEntityAttribute(
                                     v.value.trackedEntityInstance()!!,
                                     v.value.trackedEntityAttribute()!!,
-                                    FileResizerHelper.Dimension.MEDIUM.name,
+                                    //Eyeseetea customization - No resize
+                                    //,FileResizerHelper.Dimension.MEDIUM.name
                                 )
 
                             ValueType.FILE_RESOURCE ->
@@ -142,7 +143,8 @@ internal class FileResourceDownloadCall(
                         fileResourceService.getFileFromEventValue(
                             v.event()!!,
                             v.dataElement()!!,
-                            FileResizerHelper.Dimension.MEDIUM.name,
+                            //Eyeseetea customization - No resize
+                            //,FileResizerHelper.Dimension.MEDIUM.name
                         )
                     },
                     getUid = { v -> v.value() },

--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceService.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourceService.kt
@@ -45,7 +45,8 @@ internal interface FileResourceService {
     suspend fun getImageFromTrackedEntityAttribute(
         @Path(TRACKED_ENTITY_INSTANCE) trackedEntityInstanceUid: String,
         @Path(TRACKED_ENTITY_ATTRIBUTE) trackedEntityAttributeUid: String,
-        @Query("dimension") dimension: String,
+        //Eyeseetea customization - No resize
+        //   @Query("dimension") dimension: String
     ): ResponseBody
 
     @GET("$TRACKED_ENTITY_INSTANCES/{$TRACKED_ENTITY_INSTANCE}/{$TRACKED_ENTITY_ATTRIBUTE}/file")
@@ -58,7 +59,8 @@ internal interface FileResourceService {
     suspend fun getFileFromEventValue(
         @Query("eventUid") eventUid: String,
         @Query("dataElementUid") dataElementUid: String,
-        @Query("dimension") dimension: String,
+        //Eyeseetea customization - No resize
+        //@Query("dimension") dimension: String
     ): ResponseBody
 
     @GET("$DATA_VALUES/files")
@@ -67,7 +69,8 @@ internal interface FileResourceService {
         @Query("pe") period: String,
         @Query("ou") organisationUnit: String,
         @Query("co") categoryOptionCombo: String,
-        @Query("dimension") dimension: String,
+        //Eyeseetea customization - No resize
+        //@Query("dimension") dimension: String
     ): ResponseBody
 
     companion object {

--- a/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/program/ProgramStageSectionsCollectionRepository.kt
@@ -34,6 +34,7 @@ import org.hisp.dhis.android.core.arch.repositories.filters.internal.FilterConne
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.IntegerFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.filters.internal.StringFilterConnector
 import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope
+import org.hisp.dhis.android.core.arch.repositories.scope.RepositoryScope.OrderByDirection
 import org.hisp.dhis.android.core.program.internal.ProgramStageSectionDataElementChildrenAppender
 import org.hisp.dhis.android.core.program.internal.ProgramStageSectionFields
 import org.hisp.dhis.android.core.program.internal.ProgramStageSectionProgramIndicatorChildrenAppender
@@ -63,6 +64,13 @@ class ProgramStageSectionsCollectionRepository internal constructor(
     fun bySortOrder(): IntegerFilterConnector<ProgramStageSectionsCollectionRepository> {
         return cf.integer(ProgramStageSectionTableInfo.Columns.SORT_ORDER)
     }
+
+    fun orderBySortOrder(
+        direction: OrderByDirection
+    ): ProgramStageSectionsCollectionRepository {
+        return cf.withOrderBy(ProgramStageSectionTableInfo.Columns.SORT_ORDER, direction)
+    }
+
 
     fun byProgramStageUid(): StringFilterConnector<ProgramStageSectionsCollectionRepository> {
         return cf.string(ProgramStageSectionTableInfo.Columns.PROGRAM_STAGE)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/8693ntn2e #8693ntn2e
* **Related Pull request:** https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/149

###   :gear: branches 
       Origin: feature-1.9.1/fix_avoid_resize_to_download_images Target: develop-eyeseetea

### :tophat: What is the goal?

Avoid resize images to download

### :memo: How is it being implemented?

- [x] Remove request images using the dimension parameter 
-
### :boom: How can it be tested?

This is a cherry-pick for 2.9.1, there are no conflicts and can be merged

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-