### PR TITLE
Fix migration from old version to 2.9.1

### DIFF
--- a/core/src/main/assets/migrations/148.sql
+++ b/core/src/main/assets/migrations/148.sql
@@ -1,0 +1,4 @@
+# Add style properties in Indicator table (ANDROSDK-1688)
+
+ALTER TABLE Indicator ADD COLUMN color TEXT;
+ALTER TABLE Indicator ADD COLUMN icon TEXT;


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/860t03z8h
* **Related Pull request:** https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/141

###   :gear: branches 
**app**: 
       Origin: ffeature-1.9.1/fix_migration_from_old_version_to_2.9.1 Target: develop-eyeseetea

### :tophat: What is the goal?

- Fix migration from old version to 2.9.2


### :memo: How is it being implemented?

- There is a missing migration and when a migration fails this provoke a silent bug and rest of migrations are not executed provoking errors

### :boom: How can it be tested?

- Execute 2.9.1 code in a device with a previous version installed

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-