### PR TITLE
Fix multipart header for file uploads

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourcePostCall.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/fileresource/internal/FileResourcePostCall.kt
@@ -98,7 +98,7 @@ internal class FileResourcePostCall(
                     key = "file",
                     value = file.readBytes(),
                     headers = Headers.build {
-                        append(HttpHeaders.ContentDisposition, "form-data; name=\"file\"; filename=\"$fileName\"")
+                        append(HttpHeaders.ContentDisposition, "filename=\"$fileName\"")
                         append(HttpHeaders.ContentType, type)
                     },
                 )


### PR DESCRIPTION
## Summary
- avoid duplicating `Content-Disposition` header when building multipart requests

## Testing
- `./gradlew test --tests "org.hisp.dhis.android.core.arch.api.httpservice.internal.RequestBuilderShould.build_POST_request_with_Multipart_body_correctly" -x checkstyle -x lint` *(fails: Android SDK missing)*

------
https://chatgpt.com/codex/tasks/task_b_68765d210fbc832e93ec147c0bef14c9