### PR TITLE
Fix migration 301 with encrypted database

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -4127,6 +4127,7 @@ public class org/hisp/dhis/android/core/configuration/internal/DatabaseEncryptio
 public final class org/hisp/dhis/android/core/configuration/internal/DatabaseEncryptionPasswordManager {
 	public static final field Companion Lorg/hisp/dhis/android/core/configuration/internal/DatabaseEncryptionPasswordManager$Companion;
 	public fun <init> (Lorg/hisp/dhis/android/core/arch/storage/internal/SecureStore;Lorg/hisp/dhis/android/core/configuration/internal/DatabaseEncryptionPasswordGenerator;)V
+	public final fun copyPasswordForRenamedDatabase (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun deletePassword (Ljava/lang/String;)V
 	public final fun getPassword (Ljava/lang/String;)Ljava/lang/String;
 }

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigrationIntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigrationIntegrationShould.kt
@@ -91,6 +91,7 @@ class DatabaseConfigurationMigrationIntegrationShould {
         databasesConfigurationStore = DatabaseConfigurationInsecureStoreImpl(insecureStore)
         credentialsSecureStore = CredentialsSecureStoreImpl(chunkedSecureStore)
 
+        // EyeSeeTea customization
         migration = DatabaseConfigurationMigration(
             context,
             databasesConfigurationStore,
@@ -99,6 +100,7 @@ class DatabaseConfigurationMigrationIntegrationShould {
             nameGenerator,
             renamer,
             databaseManager,
+            passwordManager,
         )
 
         FileResourceDirectoryHelper.deleteRootFileResourceDirectory(context)

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/Migration301IntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/Migration301IntegrationShould.kt
@@ -31,7 +31,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper
-// EyeSeeTea customization
 import org.hisp.dhis.android.core.arch.storage.internal.InMemorySecureStore
 import org.hisp.dhis.android.core.arch.storage.internal.InMemoryUnsecureStore
 import org.hisp.dhis.android.core.configuration.internal.migration.Migration301
@@ -48,7 +47,7 @@ class Migration301IntegrationShould {
     private val databaseConfigurationStore = DatabaseConfigurationInsecureStoreImpl(InMemoryUnsecureStore())
     private val nameGenerator = DatabaseNameGenerator()
     private val renamer = DatabaseRenamer(context)
-    // EyeSeeTea customization
+
     private val passwordManager = DatabaseEncryptionPasswordManager.create(InMemorySecureStore())
 
     private lateinit var migration: Migration301

--- a/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/Migration301IntegrationShould.kt
+++ b/core/src/androidTest/java/org/hisp/dhis/android/core/configuration/internal/Migration301IntegrationShould.kt
@@ -31,6 +31,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.hisp.dhis.android.core.arch.helpers.FileResourceDirectoryHelper
+// EyeSeeTea customization
+import org.hisp.dhis.android.core.arch.storage.internal.InMemorySecureStore
 import org.hisp.dhis.android.core.arch.storage.internal.InMemoryUnsecureStore
 import org.hisp.dhis.android.core.configuration.internal.migration.Migration301
 import org.hisp.dhis.android.core.utils.runner.D2JunitRunner
@@ -46,6 +48,8 @@ class Migration301IntegrationShould {
     private val databaseConfigurationStore = DatabaseConfigurationInsecureStoreImpl(InMemoryUnsecureStore())
     private val nameGenerator = DatabaseNameGenerator()
     private val renamer = DatabaseRenamer(context)
+    // EyeSeeTea customization
+    private val passwordManager = DatabaseEncryptionPasswordManager.create(InMemorySecureStore())
 
     private lateinit var migration: Migration301
 
@@ -56,6 +60,7 @@ class Migration301IntegrationShould {
             databaseConfigurationStore,
             nameGenerator,
             renamer,
+            passwordManager,
         )
 
         cleanupTestFiles()
@@ -197,6 +202,34 @@ class Migration301IntegrationShould {
         assertHashedDbName(newDbName, encrypted = false)
         assertThat(context.getDatabasePath(newDbName).exists()).isFalse()
         assertThat(context.getDatabasePath(oldDbName).exists()).isFalse()
+    }
+
+    /**
+     * EyeSeeTea customization: Validates that when migrating an encrypted account, the
+     * encryption password is copied from the old database name to the new one in SecureStore,
+     * so the renamed database can still be opened with the same key (avoids SQLiteNotADatabaseException).
+     */
+    @Test
+    fun copy_encryption_password_to_new_db_name_when_migrating_encrypted_account() = runTest {
+        val url = "https://play.dhis2.org/encrypted-migration"
+        val username = "enc_user"
+
+        @Suppress("DEPRECATION")
+        val oldDbName = nameGenerator.getOldDatabaseName(url, username, true)
+
+        createDatabaseFile(oldDbName)
+        val passwordBeforeMigration = passwordManager.getPassword(oldDbName)
+
+        runMigration(listOf(createAccount(url, username, oldDbName, encrypted = true)))
+
+        val migratedConfig = databaseConfigurationStore.get()
+        assertThat(migratedConfig).isNotNull()
+        val newDbName = migratedConfig!!.accounts()[0].databaseName()
+        assertThat(newDbName).isNotEqualTo(oldDbName)
+        assertHashedDbName(newDbName, encrypted = true)
+
+        val passwordAfterMigration = passwordManager.getPassword(newDbName)
+        assertThat(passwordAfterMigration).isEqualTo(passwordBeforeMigration)
     }
 
     @Test

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigration.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigration.kt
@@ -42,7 +42,6 @@ import org.hisp.dhis.android.persistence.configuration.ConfigurationStoreImpl
 import org.koin.core.annotation.Singleton
 
 @Singleton
-
 internal class DatabaseConfigurationMigration(
     private val context: Context,
     private val databaseConfigurationStore: DatabaseConfigurationInsecureStore,
@@ -51,7 +50,6 @@ internal class DatabaseConfigurationMigration(
     private val nameGenerator: DatabaseNameGenerator,
     private val renamer: DatabaseRenamer,
     private val databaseManager: DatabaseManager,
-    // EyeSeeTea customization
     private val passwordManager: DatabaseEncryptionPasswordManager,
 ) {
     @Suppress("TooGenericExceptionCaught")

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigration.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseConfigurationMigration.kt
@@ -42,6 +42,7 @@ import org.hisp.dhis.android.persistence.configuration.ConfigurationStoreImpl
 import org.koin.core.annotation.Singleton
 
 @Singleton
+
 internal class DatabaseConfigurationMigration(
     private val context: Context,
     private val databaseConfigurationStore: DatabaseConfigurationInsecureStore,
@@ -50,6 +51,8 @@ internal class DatabaseConfigurationMigration(
     private val nameGenerator: DatabaseNameGenerator,
     private val renamer: DatabaseRenamer,
     private val databaseManager: DatabaseManager,
+    // EyeSeeTea customization
+    private val passwordManager: DatabaseEncryptionPasswordManager,
 ) {
     @Suppress("TooGenericExceptionCaught")
     suspend fun apply() {
@@ -98,7 +101,7 @@ internal class DatabaseConfigurationMigration(
         }
 
         runMigrationIfNeeded(existingVersionCode, Migration301.VERSION) {
-            Migration301(context, databaseConfigurationStore, nameGenerator, renamer).apply()
+            Migration301(context, databaseConfigurationStore, nameGenerator, renamer, passwordManager).apply()
         }
     }
 

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseEncryptionPasswordManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseEncryptionPasswordManager.kt
@@ -52,7 +52,7 @@ class DatabaseEncryptionPasswordManager(
     }
 
     /**
-     * EyeSeeTea customization 
+     * EyeSeeTea customization
      * Copies the encryption password from the old database name to the new one.
      * Used when migrating (e.g. renaming DB file with hash suffix) so the renamed
      * encrypted file can still be opened with the same key.

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseEncryptionPasswordManager.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/DatabaseEncryptionPasswordManager.kt
@@ -51,6 +51,18 @@ class DatabaseEncryptionPasswordManager(
         secureStore.removeData(getKey(databaseName))
     }
 
+    /**
+     * EyeSeeTea customization 
+     * Copies the encryption password from the old database name to the new one.
+     * Used when migrating (e.g. renaming DB file with hash suffix) so the renamed
+     * encrypted file can still be opened with the same key.
+     * No-op if there was no password stored for the old name.
+     */
+    fun copyPasswordForRenamedDatabase(oldDatabaseName: String, newDatabaseName: String) {
+        val existingPassword = secureStore.getData(getKey(oldDatabaseName)) ?: return
+        secureStore.setData(getKey(newDatabaseName), existingPassword)
+    }
+
     companion object {
         fun create(secureStore: SecureStore): DatabaseEncryptionPasswordManager {
             return DatabaseEncryptionPasswordManager(

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/migration/Migration301.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/migration/Migration301.kt
@@ -34,6 +34,8 @@ import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccountImport
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccountImportStatus
 import org.hisp.dhis.android.core.configuration.internal.DatabaseNameGenerator
+// EyeSeeTea customization
+import org.hisp.dhis.android.core.configuration.internal.DatabaseEncryptionPasswordManager
 import org.hisp.dhis.android.core.configuration.internal.DatabaseRenamer
 import org.hisp.dhis.android.core.configuration.internal.DatabasesConfiguration
 import java.io.File
@@ -44,26 +46,31 @@ import java.io.File
  * This migration:
  * 1. Detects and handles existing collisions
  * 2. Renames database files and their associated files (-shm, -wal, etc.)
- * 3. Renames FileResource directories (sdk_resources and sdk_cache_resources)
- * 4. Updates protectedDbName for pending imports
- * 5. Updates configuration with new database names
+ * 3. Copies encryption password from old DB name to new name (encrypted accounts only)
+ * 4. Renames FileResource directories (sdk_resources and sdk_cache_resources)
+ * 5. Updates protectedDbName for pending imports
+ * 6. Updates configuration with new database names
  *
  * The hash suffix ensures each unique URL+username combination has its own database.
  */
+
 internal class Migration301(
     private val context: Context,
     private val databaseConfigurationStore: ObjectKeyValueStore<DatabasesConfiguration>,
     private val nameGenerator: DatabaseNameGenerator,
     private val databaseRenamer: DatabaseRenamer,
+    // EyeSeeTea customization
+    private val passwordManager: DatabaseEncryptionPasswordManager,
 ) {
 
     fun apply() {
         val configuration = databaseConfigurationStore.get()
         if (configuration == null || configuration.accounts().isEmpty()) {
+            Log.i(TAG, "Migration301: no accounts to migrate, skipping")
             return
         }
 
-        Log.i(TAG, "Starting database name hash migration for ${configuration.accounts().size} accounts")
+        Log.i(TAG, "Migration301: starting database name hash migration for ${configuration.accounts().size} account(s)")
 
         val migratedAccounts = configuration.accounts().mapNotNull { account ->
             migrateAccount(account)
@@ -88,6 +95,12 @@ internal class Migration301(
 
         return try {
             val dbRenamed = renameDatabaseFile(oldDbName, newDbName)
+            Log.i(TAG, "Start fix: $oldDbName -> $newDbName")
+            // EyeSeeTea customization: copy encryption key so renamed DB can be opened
+            if (dbRenamed && account.encrypted()) {
+                passwordManager.copyPasswordForRenamedDatabase(oldDbName, newDbName)
+                Log.i(TAG, "Encryption password copied for renamed DB: $oldDbName -> $newDbName")
+            }
             renameFileResourceDirectories(oldDbName, newDbName)
             val updatedImportDB = updateImportDB(account, oldDbName, newDbName)
             val updatedAccount = account.toBuilder()

--- a/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/migration/Migration301.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/configuration/internal/migration/Migration301.kt
@@ -33,9 +33,8 @@ import org.hisp.dhis.android.core.arch.storage.internal.ObjectKeyValueStore
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccount
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccountImport
 import org.hisp.dhis.android.core.configuration.internal.DatabaseAccountImportStatus
-import org.hisp.dhis.android.core.configuration.internal.DatabaseNameGenerator
-// EyeSeeTea customization
 import org.hisp.dhis.android.core.configuration.internal.DatabaseEncryptionPasswordManager
+import org.hisp.dhis.android.core.configuration.internal.DatabaseNameGenerator
 import org.hisp.dhis.android.core.configuration.internal.DatabaseRenamer
 import org.hisp.dhis.android.core.configuration.internal.DatabasesConfiguration
 import java.io.File
@@ -59,7 +58,6 @@ internal class Migration301(
     private val databaseConfigurationStore: ObjectKeyValueStore<DatabasesConfiguration>,
     private val nameGenerator: DatabaseNameGenerator,
     private val databaseRenamer: DatabaseRenamer,
-    // EyeSeeTea customization
     private val passwordManager: DatabaseEncryptionPasswordManager,
 ) {
 
@@ -70,7 +68,10 @@ internal class Migration301(
             return
         }
 
-        Log.i(TAG, "Migration301: starting database name hash migration for ${configuration.accounts().size} account(s)")
+        Log.i(
+            TAG,
+            "Migration301: starting database name hash migration for ${configuration.accounts().size} account(s)",
+        )
 
         val migratedAccounts = configuration.accounts().mapNotNull { account ->
             migrateAccount(account)


### PR DESCRIPTION
### :pushpin: References
* **Issue:**  https://app.clickup.com/t/869by8eff #869by8eff
* **Related Pull request:** https://github.com/EyeSeeTea/dhis2-android-capture-app/pull/297

###   :gear: branches 
**app**: 
       Origin: fix/migration_301_with_encrypted_database Target: feature/bring_last_changes_1_13_0_1 

### :tophat: What is the goal?

Fix bug to migratye to existed app in 3.1 with encrypted database

### :memo: How is it being implemented?

- Copy encrypted password from old database name to new database name
- Add tests

### :boom: How can it be tested?

- The execution should work upgrading previous version in 3.1

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-