### PR TITLE
fix: discard online failures in OFFLINE_FIRST to preserve local results

### DIFF
--- a/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
+++ b/core/src/main/java/org/hisp/dhis/android/core/trackedentity/search/TrackedEntityInstanceQueryDataFetcher.kt
@@ -80,8 +80,13 @@ internal class TrackedEntityInstanceQueryDataFetcher(
                 isExhaustedOffline = instances.size < requestedLoadSize
             }
             if (result.size < requestedLoadSize && scope.mode() == RepositoryMode.OFFLINE_FIRST) {
+                // EyeSeeTea fix - if the online call fails in OFFLINE_FIRST mode, discard the
+                // online failures and show only the local results. Prevents the UI from freezing
+                // on the previous result set when the server returns an error (e.g. HTTP 400).
+                // Local Result.Failure items (e.g. missing TE type) are NOT affected — those
+                // come from transform() after this point and still propagate normally.
                 val onlineInstances = queryOnline(requestedLoadSize)
-                result.addAll(onlineInstances)
+                result.addAll(onlineInstances.filter { it.succeeded })
             }
         } else {
             val instances = queryOnline(requestedLoadSize)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** https://app.clickup.com/t/869df3ffn
* **Related Pull request:** 

###   :gear: branches 
**app**: 
       Origin: fix/tei-search-offline-first-failure Target: develop-eyseetea

### :tophat: What is the goal?

Bring last changes for app version 3.2.1.2

### :memo: How is it being implemented?

Discard online failures in OFFLINE_FIRST to preserve local results

In OFFLINE_FIRST mode, when the online call fails (e.g. HTTP 400, timeout),
the failure was added to the result list and propagated to the PagingSource
as LoadResult.Error, which caused Paging3 to discard the offline results
already collected and freeze the UI on the previous result set.

Fix: filter out online Result.Failure items before merging with local
results. Local failures from transform() (e.g. missing TrackedEntityType)
are unaffected — they originate after this point and still propagate.

### :boom: How can it be tested?

Searches should works in local if there is network and threre is no connectivity to the server (example VPN OFF)

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-